### PR TITLE
Fix swipe deck index update race

### DIFF
--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -86,12 +86,13 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
       }
 
       setTimeout(() => {
-        const nextIndex = currentIndex + 1;
-        setCurrentIndex(nextIndex);
-
-        if (nextIndex >= data.length && onDeckEmpty) {
-          onDeckEmpty();
-        }
+        setCurrentIndex((prevIndex) => {
+          const nextIndex = prevIndex + 1;
+          if (nextIndex >= data.length && onDeckEmpty) {
+            onDeckEmpty();
+          }
+          return nextIndex;
+        });
       }, 300);
     },
     [
@@ -118,12 +119,13 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
       }
 
       setTimeout(() => {
-        const nextIndex = currentIndex + 1;
-        setCurrentIndex(nextIndex);
-
-        if (nextIndex >= data.length && onDeckEmpty) {
-          onDeckEmpty();
-        }
+        setCurrentIndex((prevIndex) => {
+          const nextIndex = prevIndex + 1;
+          if (nextIndex >= data.length && onDeckEmpty) {
+            onDeckEmpty();
+          }
+          return nextIndex;
+        });
       }, 300);
     },
     [


### PR DESCRIPTION
## Summary
- fix race conditions when updating swipe deck index

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_683f61258d6c832bae21a9f60a04731c