### PR TITLE
Implement permanent photo deletion

### DIFF
--- a/app/(drawer)/(tabs)/recycle-bin.tsx
+++ b/app/(drawer)/(tabs)/recycle-bin.tsx
@@ -1,6 +1,6 @@
 import { Stack } from 'expo-router';
 import { View, ScrollView, Image, Dimensions, Alert, TouchableOpacity } from 'react-native';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { Container } from '~/components/Container';
 import { Text } from '~/components/nativewindui/Text';
@@ -98,7 +98,12 @@ const RecycleBinItem: React.FC<RecycleBinItemProps> = ({ photo, onRestore, onPer
 };
 
 export default function RecycleBin() {
-  const { deletedPhotos, restorePhoto, permanentlyDelete, clearRecycleBin } = useRecycleBinStore();
+  const { deletedPhotos, restorePhoto, permanentlyDelete, clearRecycleBin, purgeExpiredPhotos } =
+    useRecycleBinStore();
+
+  useEffect(() => {
+    purgeExpiredPhotos();
+  }, [purgeExpiredPhotos]);
 
   const handleRestore = (photoId: string) => {
     const restoredPhoto = restorePhoto(photoId);
@@ -110,8 +115,8 @@ export default function RecycleBin() {
     }
   };
 
-  const handlePermanentDelete = (photoId: string) => {
-    permanentlyDelete(photoId);
+  const handlePermanentDelete = async (photoId: string) => {
+    await permanentlyDelete(photoId);
     Alert.alert(
       'Photo Deleted',
       `The photo has been permanently deleted.\n\n⭐ +${XP_CONFIG.PERMANENT_DELETE} XP`
@@ -129,9 +134,9 @@ export default function RecycleBin() {
         {
           text: 'Clear All',
           style: 'destructive',
-          onPress: () => {
+          onPress: async () => {
             const photosCount = deletedPhotos.length;
-            clearRecycleBin();
+            await clearRecycleBin();
             Alert.alert(
               'Recycle Bin Cleared',
               `All photos have been permanently deleted.\n\n⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,7 +24,7 @@ export {
 export default function RootLayout() {
   useInitialAndroidBarSync();
   const { colorScheme, isDarkColorScheme } = useColorScheme();
-  const { loadXP, isXpLoaded, checkOnboardingStatus } = useRecycleBinStore();
+  const { loadXP, loadDeletedPhotos, isXpLoaded, checkOnboardingStatus } = useRecycleBinStore();
   const segments = useSegments();
   const router = useRouter();
 
@@ -32,8 +32,9 @@ export default function RootLayout() {
   useEffect(() => {
     if (!isXpLoaded) {
       loadXP();
+      loadDeletedPhotos();
     }
-  }, [loadXP, isXpLoaded]);
+  }, [loadXP, loadDeletedPhotos, isXpLoaded]);
 
   // Check onboarding status on startup
   useEffect(() => {

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -46,12 +46,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       setSessionStartXp(currentXp);
       setSessionDeletedStart(currentDeleted.length);
 
-      const photoUris = await fetchPhotoAssets(50); // Load first 50 photos
-      const photoItems: SwipeDeckItem[] = photoUris.map((uri) => ({
-        // Use the uri itself as a stable id so deleted photos aren't blocked
-        // by duplicate IDs when a new session begins
-        id: uri,
-        imageUri: uri,
+      const assets = await fetchPhotoAssets(50); // Load first 50 photos
+      const photoItems: SwipeDeckItem[] = assets.map((asset) => ({
+        // Use the asset id as stable identifier
+        id: asset.id,
+        imageUri: asset.uri,
       }));
 
       if (!isMounted.current) return false;


### PR DESCRIPTION
## Summary
- return asset IDs when loading photo assets
- add deletion helpers in media library util
- enable permanent delete in recycle bin actions
- load asset IDs in photo gallery
- await delete/clear operations in recycle bin screen
- automatically purge items older than 30 days
- persist recycle bin contents and load them on startup
- purge expired items when deleted photos are loaded
- format codebase

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846ac358c50832b8d7cc28d3d0e1623