### PR TITLE
Add motivation banner

### DIFF
--- a/components/MotivationBanner.tsx
+++ b/components/MotivationBanner.tsx
@@ -1,0 +1,25 @@
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { Text } from '~/components/nativewindui/Text';
+
+const MESSAGES = [
+  'Great job keeping your gallery tidy!',
+  'Every swipe counts toward a cleaner phone!',
+  'You\'re doing awesome, keep it up!',
+  'Nice work! Your photos appreciate the love.',
+];
+
+export const MotivationBanner: React.FC = () => {
+  const message = useMemo(
+    () => MESSAGES[Math.floor(Math.random() * MESSAGES.length)],
+    []
+  );
+
+  return (
+    <View className="mb-4 rounded-xl bg-green-50 px-4 py-2 dark:bg-green-900">
+      <Text className="text-center" color="secondary">
+        {message}
+      </Text>
+    </View>
+  );
+};

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -8,6 +8,7 @@ import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
 import { cn } from '~/lib/cn';
 import { useRecycleBinStore, DeletedPhoto } from '~/store/store';
+import { MotivationBanner } from './MotivationBanner';
 
 interface PhotoGalleryProps {
   className?: string;
@@ -198,6 +199,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
 
   return (
     <View className={cn('flex-1 items-center justify-center', className)}>
+      <MotivationBanner />
       {/* Stats */}
       <View className="mb-6 flex-row space-x-6">
         <View className="items-center">


### PR DESCRIPTION
## Summary
- add a new `MotivationBanner` component to display random positive messages
- show the banner in `PhotoGallery` above the stats

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_684749a64df8832b9e552536b38a6b2e