### PR TITLE
Fix missing native module errors

### DIFF
--- a/app/(drawer)/(tabs)/_layout.tsx
+++ b/app/(drawer)/(tabs)/_layout.tsx
@@ -3,7 +3,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { View, Text } from 'react-native';
 import { useEffect, useRef } from 'react';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import * as Haptics from 'expo-haptics';
 import { useRecycleBinStore } from '~/store/store';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
 
@@ -39,7 +38,11 @@ function XPDisplay() {
     scale.value = withTiming(1, { duration: 300 });
 
     if (level > prevLevel.current) {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {});
+      import('expo-haptics')
+        .then((Haptics) =>
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {})
+        )
+        .catch(() => {});
     }
     prevLevel.current = level;
   }, [xp, level, scale]);

--- a/lib/useColorScheme.tsx
+++ b/lib/useColorScheme.tsx
@@ -50,9 +50,18 @@ function setNavigationBar(colorScheme: 'light' | 'dark') {
   if (Platform.OS !== 'android') {
     return Promise.resolve();
   }
+  if (
+    !NavigationBar.setButtonStyleAsync ||
+    !NavigationBar.setPositionAsync ||
+    !NavigationBar.setBackgroundColorAsync
+  ) {
+    return Promise.resolve();
+  }
   return Promise.all([
     NavigationBar.setButtonStyleAsync(colorScheme === 'dark' ? 'light' : 'dark'),
     NavigationBar.setPositionAsync('absolute'),
-    NavigationBar.setBackgroundColorAsync(colorScheme === 'dark' ? '#00000030' : '#ffffff80'),
+    NavigationBar.setBackgroundColorAsync(
+      colorScheme === 'dark' ? '#00000030' : '#ffffff80'
+    ),
   ]);
 }

--- a/lib/useSwipeAudio.ts
+++ b/lib/useSwipeAudio.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import * as Haptics from 'expo-haptics';
 import { useAudioSettings } from './useAudioSettings';
 import { audioService } from './audioService';
 
@@ -32,14 +31,22 @@ export const useSwipeAudio = () => {
 
   const playDeleteSound = () => {
     audioService.playDeleteSound();
-    // Trigger a strong haptic impact when a photo is deleted
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {});
+    // Trigger a strong haptic impact when a photo is deleted, if available
+    import('expo-haptics')
+      .then((Haptics) =>
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {})
+      )
+      .catch(() => {});
   };
 
   const playKeepSound = () => {
     audioService.playKeepSound();
-    // Provide lighter feedback for keeping a photo
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    // Provide lighter feedback for keeping a photo, if available
+    import('expo-haptics')
+      .then((Haptics) =>
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {})
+      )
+      .catch(() => {});
   };
 
   return {


### PR DESCRIPTION
## Summary
- avoid requiring expo-haptics at import time
- guard Android navigation bar API calls
- use dynamic import for XP level-up feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684828de69cc832bab7901f94cea309b