### PR TITLE
Update Android build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Minimal photo clean-up game built with Expo React Native.
 npm start
 ```
 
+Expo Go cannot grant full media-library permissions. Features like file deletion
+and scanning require a development build. Create one with:
+
+```bash
+eas build --profile development
+```
+
+or
+
+```bash
+expo run:android
+```
+
 XP and onboarding progress are stored using AsyncStorage. If storage is
 unavailable, an in-memory fallback ensures the app still works.
 


### PR DESCRIPTION
## Summary
- document that Expo Go can't grant full media-library access
- recommend creating a development build for scanning and file deletion

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_684852b81df0832b9c8a1839bb5705cb