### PR TITLE
Delay photo deletion until recycle bin cleared

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Alert, Dimensions } from 'react-native';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
-import { fetchPhotoAssetsWithPagination, deletePhotoAsset } from '~/lib/mediaLibrary';
+import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
@@ -126,10 +126,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     // Update current photo index for tracking progress
     setCurrentPhotoIndex((prev) => prev + 1);
 
-    // Immediately delete the photo from the device
-    deletePhotoAsset(item.id).catch((err) => {
-      console.error('Failed to delete photo asset:', err);
-    });
+    // Deletion from the device now happens when the recycle bin is cleared
+    // or a photo is permanently deleted from within the recycle bin screen.
   };
 
   const handleSwipeRight = (item: SwipeDeckItem, index: number) => {


### PR DESCRIPTION
## Summary
- stop deleting images as soon as they are swiped left
- update recycle bin store tests to verify restore path and deletion hooks

## Testing
- `node node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68484ebb9020832bbe4deb33052e9e9f