### PR TITLE
Fix ExoPlayer threading and document tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ For more details on specific systems see:
 - `ONBOARDING_README.md`
 - `XP_SYSTEM_README.md`
 
+## Testing
+
+Run the automated test suite after installing dependencies:
+
+```bash
+npm install
+npm test
+```
+
+`npm install` is required so that dev dependencies like Jest are available and
+the `patch-package` script can apply fixes to expo-audio.
+
 ## Performance Tips
 
 ### Faster installation

--- a/patches/expo-audio+0.4.5.patch
+++ b/patches/expo-audio+0.4.5.patch
@@ -1,4 +1,5 @@
 diff --git a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+index 13a3c24..cac20be 100644
 --- a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
 +++ b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
 @@ -63,7 +63,7 @@ class AudioModule : Module() {
@@ -43,6 +44,15 @@ diff --git a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/Au
                player.isPaused = true
 -              player.ref.pause()
 +              runOnMain { player.ref.pause() }
+             }
+           }
+ 
+@@ -195,7 +195,7 @@ class AudioModule : Module() {
+           players.values.forEach { player ->
+             if (player.isPaused) {
+               player.isPaused = false
+-              player.ref.play()
++              runOnMain { player.ref.play() }
              }
            }
  


### PR DESCRIPTION
## Summary
- wrap expo-audio player calls in `runOnMain`
- document how to run tests so dev dependencies are installed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68486f73331c832ba8220fd2493826c3