### PR TITLE
Improve motivational messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ unavailable, an in-memory fallback ensures the app still works.
 2. **Gallery Game**
    - A stack of recent photos is loaded.
    - Swipe **left** to delete (plays a sound and grants XP) or **right** to keep.
-   - When the stack is empty an alert summarizes how many photos you deleted and XP earned.
+  - When the stack is empty an alert summarizes how many photos you deleted and XP earned.
+  - Friendly alerts celebrate your progress and encourage you to keep going.
+  - A motivational banner shows supportive messages to keep you feeling positive while you declutter.
+  - Messages are chosen from a shared module and cycled so you rarely see the same encouragement twice in a row.
 
 - If more images are available the next batch loads automatically so the game never ends until your gallery is empty. The app also prefetches the following batch in the background to keep swiping smooth.
 

--- a/__tests__/positiveMessages.test.ts
+++ b/__tests__/positiveMessages.test.ts
@@ -1,0 +1,16 @@
+import { randomMessage, createMessagePicker } from '../lib/positiveMessages';
+
+test('randomMessage returns element from list', () => {
+  const items = ['a', 'b', 'c'];
+  const msg = randomMessage(items);
+  expect(items).toContain(msg);
+});
+
+test('createMessagePicker avoids immediate repeats', () => {
+  const items = ['a', 'b'];
+  const pick = createMessagePicker(items);
+  const first = pick();
+  const second = pick();
+  expect(second).not.toBe(first);
+  expect(items).toContain(second);
+});

--- a/components/MotivationBanner.tsx
+++ b/components/MotivationBanner.tsx
@@ -1,19 +1,16 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { Text } from '~/components/nativewindui/Text';
+import {
+  MOTIVATION_MESSAGES,
+  createMessagePicker,
+} from '~/lib/positiveMessages';
 
-const MESSAGES = [
-  'Great job keeping your gallery tidy!',
-  'Every swipe counts toward a cleaner phone!',
-  'You\'re doing awesome, keep it up!',
-  'Nice work! Your photos appreciate the love.',
-];
+const MESSAGES = MOTIVATION_MESSAGES;
+const pickMessage = createMessagePicker(MESSAGES);
 
 export const MotivationBanner: React.FC = () => {
-  const message = useMemo(
-    () => MESSAGES[Math.floor(Math.random() * MESSAGES.length)],
-    []
-  );
+  const message = useMemo(() => pickMessage(), []);
 
   return (
     <View className="mb-4 rounded-xl bg-green-50 px-4 py-2 dark:bg-green-900">

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -9,6 +9,15 @@ import { Button } from '~/components/nativewindui/Button';
 import { cn } from '~/lib/cn';
 import { useRecycleBinStore, DeletedPhoto } from '~/store/store';
 import { MotivationBanner } from './MotivationBanner';
+import {
+  SESSION_MESSAGES,
+  END_MESSAGES,
+  createMessagePicker,
+} from '~/lib/positiveMessages';
+
+const pickSessionMessage = createMessagePicker(SESSION_MESSAGES);
+const pickEndMessage = createMessagePicker(END_MESSAGES);
+
 
 interface PhotoGalleryProps {
   className?: string;
@@ -175,22 +184,25 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         } else {
           setHasMore(false);
         }
+        const msg = pickSessionMessage();
         Alert.alert(
-          'More Photos Loaded!',
+          msg,
           `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`
         );
       } else {
         loadPhotos().then(() => {
+          const msg = pickSessionMessage();
           Alert.alert(
-            'More Photos Loaded!',
+            msg,
             `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`
           );
         });
       }
     } else {
+      const endMsg = pickEndMessage();
       Alert.alert(
-        'No More Photos',
-        `You've reached the end of your gallery.\n\nDeleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`,
+        endMsg,
+        `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`,
         [{ text: 'OK', style: 'default' }]
       );
     }

--- a/lib/positiveMessages.ts
+++ b/lib/positiveMessages.ts
@@ -1,0 +1,42 @@
+export const MOTIVATION_MESSAGES = [
+  'Great job keeping your gallery tidy!',
+  'Every swipe counts toward a cleaner phone!',
+  "You're doing awesome, keep it up!",
+  'Nice work! Your photos appreciate the love.',
+  'You deserve a clutter\u2011free gallery!',
+  'Every photo you clear makes room for joy!',
+  "You're in control and doing great!",
+  'Clutter\u2011free gallery, clutter\u2011free mind!',
+  'Your progress is inspiring!',
+  'Looking cool while cleaning up!',
+  'Swipe power activated!'
+] as const;
+
+export const SESSION_MESSAGES = [
+  'Great progress! Ready for more?',
+  'Awesome work! Your gallery is getting cleaner.',
+  'Looking good! New photos just arrived.',
+  'Fantastic job! Keep enjoying the declutter.',
+] as const;
+
+export const END_MESSAGES = [
+  "You're all caught up!",
+  'Gallery all cleaned up!',
+  'Nice work, no more photos!',
+] as const;
+
+export function randomMessage(messages: readonly string[]): string {
+  return messages[Math.floor(Math.random() * messages.length)];
+}
+
+export function createMessagePicker(messages: readonly string[]): () => string {
+  let last = -1;
+  return () => {
+    let index = Math.floor(Math.random() * messages.length);
+    if (messages.length > 1 && index === last) {
+      index = (index + 1) % messages.length;
+    }
+    last = index;
+    return messages[index];
+  };
+}


### PR DESCRIPTION
## Summary
- add cooler encouragement text and prevent repeated messages
- implement `createMessagePicker` helper
- use picker in banner and gallery alerts
- cycle messages so they rarely repeat
- expand tests for the new helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68487fbeaf30832b81f7902da1a2c34f