### PR TITLE
Add mascot doc and mention Flappy Bird inspiration

### DIFF
--- a/MASCOT_README.md
+++ b/MASCOT_README.md
@@ -1,0 +1,17 @@
+# Mascot Design
+
+The game features a playful mascot that appears during level-up events and onboarding screens. The style should evoke the simplicity and charm of **Flappy Bird**, using chunky pixels and a bright color palette.
+
+## Inspiration
+
+- Short, looping flapping animation similar to Flappy Bird
+- Rounded beak and simple eyes so expression is easy to read
+- Keep the sprite small enough to fit next to score and XP displays
+
+## Usage
+
+- Trigger a quick flap animation when the user levels up
+- Optionally display the mascot on the home screen or while loading photos
+- Keep the sprite sheet minimal (3–4 frames) so it performs well on low-end devices
+
+The mascot does not need to match Flappy Bird exactly—use it as a baseline for proportions and movement. A few color tweaks or accessories can help it feel unique to DeCluttr.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DeCluttr
 
 Minimal photo clean-up game built with Expo React Native.
+It features a small bird mascot inspired by **Flappy Bird** that celebrates your progress.
 **Android only** – other platforms are not supported.
 
 ## Prerequisites
@@ -76,6 +77,7 @@ For more details on specific systems see:
 - `AUDIO_SYSTEM_README.md`
 - `ONBOARDING_README.md`
 - `XP_SYSTEM_README.md`
+- `MASCOT_README.md`
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- add new `MASCOT_README.md` describing the mascot style
- link to the mascot doc from README
- note in README that the game now features a Flappy Bird inspired mascot

## Testing
- `npm install --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run format --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848987b0fbc832ba2bf3cc5e9c6b88c