### PR TITLE
Limit message length and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ unavailable, an in-memory fallback ensures the app still works.
   - Friendly alerts celebrate your progress and encourage you to keep going.
   - A motivational banner shows supportive messages to keep you feeling positive while you declutter.
   - Messages are chosen from a shared module and cycled so you rarely see the same encouragement twice in a row.
+  - Customize these phrases in `lib/positiveMessages.ts`; keep each under 30 characters so they fit the banner.
 
 - If more images are available the next batch loads automatically so the game never ends until your gallery is empty. The app also prefetches the following batch in the background to keep swiping smooth.
 

--- a/__tests__/shortMessages.test.ts
+++ b/__tests__/shortMessages.test.ts
@@ -1,0 +1,13 @@
+import {
+  MOTIVATION_MESSAGES,
+  SESSION_MESSAGES,
+  END_MESSAGES,
+  MAX_MESSAGE_LENGTH,
+} from '../lib/positiveMessages';
+
+test('all messages are short', () => {
+  const all = [...MOTIVATION_MESSAGES, ...SESSION_MESSAGES, ...END_MESSAGES];
+  for (const msg of all) {
+    expect(msg.length).toBeLessThanOrEqual(MAX_MESSAGE_LENGTH);
+  }
+});

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -10,28 +10,22 @@ import { useColorScheme } from '~/lib/useColorScheme';
 // Screen images
 const screens = [
   {
-    title: 'Declutter Your Photos',
-    subtitle: 'Swipe left to remove photos you no longer need, swipe right to keep them.',
-    image: <Image source={require('../assets/onboarding/step-1.png')} />, // Using app icon
+    title: 'Declutter Photos',
+    subtitle: 'Swipe left to delete, right to keep.',
+    image: <Image source={require('../assets/onboarding/step-1.png')} />,
     backgroundColor: '#025CBD',
   },
   {
     title: 'Recycle Bin',
-    subtitle: 'Deleted photos go to the Recycle Bin. You can restore them anytime.',
-    image: <Image source={require('../assets/onboarding/step-2.png')} />, // Using app icon
+    subtitle: 'Restore deleted photos anytime.',
+    image: <Image source={require('../assets/onboarding/step-2.png')} />,
     backgroundColor: '#E33131',
   },
   {
     title: 'Earn XP',
-    subtitle: 'Earn experience points for decluttering your photos. Track your progress!',
-    image: <Image source={require('../assets/onboarding/step-3.png')} />, // Using app icon
+    subtitle: 'Gain points as you clean.',
+    image: <Image source={require('../assets/onboarding/step-3.png')} />,
     backgroundColor: '#025CBD',
-  },
-  {
-    title: 'Earn XP',
-    subtitle: 'Earn experience points for decluttering your photos. Track your progress!',
-    image: <Image source={require('../assets/onboarding/step-4.png')} />, // Using app icon
-    backgroundColor: '#E33131',
   },
 ];
 

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -326,7 +326,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       {/* Swipe Instructions */}
       <View className="mb-6 px-8">
         <Text variant="subhead" color="secondary" className="text-center">
-          Swipe left to delete • Swipe right to keep
+          Swipe left to delete, right to keep
         </Text>
       </View>
 

--- a/lib/positiveMessages.ts
+++ b/lib/positiveMessages.ts
@@ -1,34 +1,39 @@
+/** Maximum length for in-app messages. */
+export const MAX_MESSAGE_LENGTH = 30 as const;
+
 export const MOTIVATION_MESSAGES = [
-  'Great job keeping your gallery tidy!',
-  'Every swipe counts toward a cleaner phone!',
-  "You're doing awesome, keep it up!",
-  'Nice work! Your photos appreciate the love.',
-  'You deserve a clutter\u2011free gallery!',
-  'Every photo you clear makes room for joy!',
-  "You're in control and doing great!",
-  'Clutter\u2011free gallery, clutter\u2011free mind!',
-  'Your progress is inspiring!',
-  'Looking cool while cleaning up!',
-  'Swipe power activated!'
+  'Great job!',
+  'Every swipe counts!',
+  'Keep it up!',
+  'Nice work!',
+  'Clutter\u2011free gallery!',
+  'Room for joy!',
+  "You're in control!",
+  'Clear mind!',
+  'Inspiring progress!',
+  'Looking cool!',
+  'Swipe power!',
 ] as const;
 
 export const SESSION_MESSAGES = [
-  'Great progress! Ready for more?',
-  'Awesome work! Your gallery is getting cleaner.',
-  'Looking good! New photos just arrived.',
-  'Fantastic job! Keep enjoying the declutter.',
+  'Ready for more?',
+  'Gallery cleaner!',
+  'New photos arrived!',
+  'Great declutter!',
 ] as const;
 
-export const END_MESSAGES = [
-  "You're all caught up!",
-  'Gallery all cleaned up!',
-  'Nice work, no more photos!',
-] as const;
+export const END_MESSAGES = ['All caught up!', 'Gallery clean!', 'No more photos!'] as const;
 
+/**
+ * Return a random element from the provided list.
+ */
 export function randomMessage(messages: readonly string[]): string {
   return messages[Math.floor(Math.random() * messages.length)];
 }
 
+/**
+ * Create a picker that avoids repeating the last message.
+ */
 export function createMessagePicker(messages: readonly string[]): () => string {
   let last = -1;
   return () => {


### PR DESCRIPTION
## Summary
- enforce a max message length constant
- test all message arrays stay within the limit
- mention how to tweak short messages in the README

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6848aa078a64832ba64226d603409a98