### PR TITLE
Update Jest config for tsx tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',
   },


### PR DESCRIPTION
## Summary
- allow `.test.tsx` files in Jest's testMatch pattern

## Testing
- `npm run format` *(fails: Cannot find module 'eslint/config')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849413c7a78832ba364e477a59ede82