### PR TITLE
Fix useSwipeAudio test initialization

### DIFF
--- a/__tests__/useSwipeAudio.test.tsx
+++ b/__tests__/useSwipeAudio.test.tsx
@@ -12,17 +12,17 @@ jest.mock('../lib/useAudioSettings', () => ({
   }),
 }));
 
-const mockAudio = {
-  initialize: jest.fn().mockResolvedValue(undefined),
-  setVolume: jest.fn().mockResolvedValue(undefined),
-  setEnabled: jest.fn().mockResolvedValue(undefined),
-  playDeleteSound: jest.fn(),
-  playKeepSound: jest.fn(),
-};
-
-jest.mock('../lib/audioService', () => ({
-  audioService: mockAudio,
-}));
+var mockAudio: any;
+jest.mock('../lib/audioService', () => {
+  mockAudio = {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    setVolume: jest.fn().mockResolvedValue(undefined),
+    setEnabled: jest.fn().mockResolvedValue(undefined),
+    playDeleteSound: jest.fn(),
+    playKeepSound: jest.fn(),
+  };
+  return { audioService: mockAudio };
+});
 
 jest.mock('expo-haptics', () => ({
   impactAsync: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
- fix ReferenceError in `useSwipeAudio` test by initializing mock within `jest.mock`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684951e929ac832b9a21324bd68cc77c