### PR TITLE
Improve production build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ expo run:android
 ```
 
 For a release build you'll need the EAS CLI installed (this repository includes
-`eas-cli` as a dev dependency). Log in and run the production build script:
+`eas-cli` as a dev dependency). Log in and run the production build script,
+which checks your login status automatically:
 
 ```bash
 npx eas login
 npm run build:prod
 ```
-This executes `eas build --profile production`.
+This will invoke `eas build --profile production` if you are logged in.
 
 XP and onboarding progress are stored using AsyncStorage. If storage is
 unavailable, an in-memory fallback ensures the app still works.

--- a/build-prod.js
+++ b/build-prod.js
@@ -1,0 +1,23 @@
+const { execSync, spawn } = require('child_process');
+
+function checkLogin() {
+  try {
+    const output = execSync('npx eas whoami', { encoding: 'utf8' }).trim();
+    if (output.includes('Not logged in')) {
+      console.error('EAS CLI is not logged in. Run "npx eas login" before building.');
+      process.exit(1);
+    }
+  } catch {
+    console.error('Failed to run "eas" command. Ensure eas-cli is installed.');
+    process.exit(1);
+  }
+}
+
+function runBuild() {
+  const args = ['eas', 'build', '--profile', 'production'];
+  const child = spawn('npx', args, { stdio: 'inherit' });
+  child.on('exit', code => process.exit(code));
+}
+
+checkLogin();
+runBuild();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "build:dev": "eas build --profile development",
     "build:preview": "eas build --profile preview",
-    "build:prod": "eas build --profile production",
+    "build:prod": "node build-prod.js",
     "prebuild": "expo prebuild",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\" && prettier -c \"**/*.{js,jsx,ts,tsx,json}\"",
     "format": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix && prettier \"**/*.{js,jsx,ts,tsx,json}\" --write",


### PR DESCRIPTION
## Summary
- add a `build-prod.js` helper that checks if EAS CLI is logged in before running the build
- call the helper from the `build:prod` npm script
- clarify README instructions for creating a production build

## Testing
- `npm run lint`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685a80d6e6d0832bb20ab166c78db035