### PR TITLE
Add Zen Mode for minimal gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It features a small bird mascot inspired by **Flappy Bird** that celebrates your
 8. Subtle haptic feedback triggers on each swipe for extra game feel.
 9. A small header widget shows your **level** and XP with a progress bar that fills as you get closer to leveling up.
 10. The file `assets/favicon.png` serves as the favicon when running on the web. Replace it with your own image to customize the icon.
+11. Enable **Zen Mode** from the gallery screen to hide stats and confetti for a stress-free experience.
 
 ## Running the App on Android
 

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -6,6 +6,7 @@ import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
+import { Toggle } from '~/components/nativewindui/Toggle';
 import { cn } from '~/lib/cn';
 import { useRecycleBinStore, DeletedPhoto } from '~/store/store';
 import { MotivationBanner } from './MotivationBanner';
@@ -33,6 +34,10 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     };
   }, []);
 
+  useEffect(() => {
+    loadZenMode();
+  }, [loadZenMode]);
+
   const [photos, setPhotos] = useState<SwipeDeckItem[]>([]);
   const [prefetchedPhotos, setPrefetchedPhotos] = useState<SwipeDeckItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -57,6 +62,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     xp,
     resetGallery: resetRecycleBinStore,
     isXpLoaded,
+    zenMode,
+    setZenMode,
+    loadZenMode,
   } = useRecycleBinStore();
 
   const loadPhotos = React.useCallback(async (cursor?: string): Promise<boolean> => {
@@ -312,34 +320,36 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     <Pressable
       onPress={handleDebugTap}
       className={cn('flex-1 items-center justify-center', className)}>
-      <MotivationBanner />
+      {!zenMode && <MotivationBanner />}
       {/* Stats */}
-      <View className="mb-6 flex-row space-x-6">
-        <View className="items-center">
-          <Text variant="title2" className="font-arcade text-red-600">
-            {deletedPhotos.length}
-          </Text>
-          <Text variant="caption1" color="secondary">
-            In Bin
-          </Text>
+      {!zenMode && (
+        <View className="mb-6 flex-row space-x-6">
+          <View className="items-center">
+            <Text variant="title2" className="font-arcade text-red-600">
+              {deletedPhotos.length}
+            </Text>
+            <Text variant="caption1" color="secondary">
+              In Bin
+            </Text>
+          </View>
+          <View className="items-center">
+            <Text variant="title2" className="font-arcade text-green-600">
+              {keptPhotos.length}
+            </Text>
+            <Text variant="caption1" color="secondary">
+              Kept
+            </Text>
+          </View>
+          <View className="items-center">
+            <Text variant="title2" className="font-arcade text-yellow-600">
+              {totalDeleted}
+            </Text>
+            <Text variant="caption1" color="secondary">
+              All-Time Deleted
+            </Text>
+          </View>
         </View>
-        <View className="items-center">
-          <Text variant="title2" className="font-arcade text-green-600">
-            {keptPhotos.length}
-          </Text>
-          <Text variant="caption1" color="secondary">
-            Kept
-          </Text>
-        </View>
-        <View className="items-center">
-          <Text variant="title2" className="font-arcade text-yellow-600">
-            {totalDeleted}
-          </Text>
-          <Text variant="caption1" color="secondary">
-            All-Time Deleted
-          </Text>
-        </View>
-      </View>
+      )}
 
       {/* Swipe Instructions */}
       <View className="mb-6 px-8">
@@ -359,7 +369,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       />
 
       {/* Confetti burst when deleting */}
-      {confettiKey > 0 && (
+      {confettiKey > 0 && !zenMode && (
         <ConfettiCannon
           key={confettiKey}
           count={30}
@@ -373,6 +383,12 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         <Button variant="primary" onPress={resetGallery} className="bg-red-500">
           <Text className="text-white">Reset Gallery & XP</Text>
         </Button>
+        <View className="mt-4 flex-row items-center justify-center space-x-2">
+          <Text variant="caption1" color="secondary">
+            Zen Mode
+          </Text>
+          <Toggle value={zenMode} onValueChange={setZenMode} />
+        </View>
       </View>
     </Pressable>
   );

--- a/store/store.ts
+++ b/store/store.ts
@@ -28,6 +28,7 @@ const XP_STORAGE_KEY = '@decluttr_xp';
 const ONBOARDING_STORAGE_KEY = '@decluttr_onboarding_completed';
 const DELETED_PHOTOS_STORAGE_KEY = '@decluttr_deleted_photos';
 const TOTAL_DELETED_STORAGE_KEY = '@decluttr_total_deleted';
+const ZEN_MODE_STORAGE_KEY = '@decluttr_zen_mode';
 
 // RecycleBin types
 export interface DeletedPhoto {
@@ -43,6 +44,7 @@ export interface RecycleBinState {
   xp: number;
   isXpLoaded: boolean;
   onboardingCompleted: boolean;
+  zenMode: boolean;
   addDeletedPhoto: (photo: DeletedPhoto) => void;
   restorePhoto: (photoId: string) => DeletedPhoto | null;
   permanentlyDelete: (photoId: string) => Promise<void>;
@@ -64,6 +66,8 @@ export interface RecycleBinState {
   checkOnboardingStatus: () => Promise<boolean>;
   completeOnboarding: () => Promise<void>;
   resetOnboarding: () => Promise<void>;
+  loadZenMode: () => Promise<void>;
+  setZenMode: (value: boolean) => Promise<void>;
 }
 
 export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
@@ -72,6 +76,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   xp: 0,
   isXpLoaded: false,
   onboardingCompleted: false,
+  zenMode: false,
 
   // Helper to persist deleted photos
   saveDeletedPhotos: async (photos: DeletedPhoto[]) => {
@@ -118,6 +123,29 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
       console.error('Error in loadXP:', error);
       // If there's an error, just mark as loaded with 0 XP
       set({ xp: 0, isXpLoaded: true });
+    }
+  },
+
+  loadZenMode: async () => {
+    try {
+      const storage = getAsyncStorage();
+      const stored = await storage.getItem(ZEN_MODE_STORAGE_KEY);
+      const zen = stored === 'true';
+      set({ zenMode: zen });
+    } catch (error) {
+      console.error('Failed to load zen mode:', error);
+      set({ zenMode: false });
+    }
+  },
+
+  setZenMode: async (value: boolean) => {
+    try {
+      set({ zenMode: value });
+      const storage = getAsyncStorage();
+      await storage.setItem(ZEN_MODE_STORAGE_KEY, value ? 'true' : 'false');
+    } catch (error) {
+      console.error('Failed to set zen mode:', error);
+      set({ zenMode: value });
     }
   },
 


### PR DESCRIPTION
## Summary
- add `zenMode` state to the store with persistence helpers
- hide motivation banner, stats and confetti when Zen Mode is on
- include a Zen Mode toggle in the gallery
- document the new feature in the README

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685a89a03de8832bb47cdee21d09ff5e