### PR TITLE
Restrict confetti and XP animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It features a small bird mascot inspired by **Flappy Bird** that celebrates your
 3. Add sound effects by following the instructions in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 4. (Optional) Place a music file at `assets/music/background.mp3` to enable looping background music. The app starts this track automatically.
 5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep.
-6. For a nostalgic feel, pick short 8-bit style clips reminiscent of retro Nintendo games. A confetti burst rewards each successful delete.
+6. For a nostalgic feel, pick short 8-bit style clips reminiscent of retro Nintendo games. A confetti burst celebrates each level up.
 7. The `audioService` will load these sounds automatically and handle failures gracefully.
 8. Subtle haptic feedback triggers on each swipe for extra game feel.
 9. A small header widget shows your **level** and XP with a progress bar that fills as you get closer to leveling up.

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -33,15 +33,14 @@ function XPDisplay() {
   const level = Math.floor(xp / 100) + 1;
   const progress = xp % 100;
 
-  // Animate XP display. Bigger bounce and a slight rotation on level up.
+  // Animate XP display only when leveling up
   useEffect(() => {
     const leveledUp = level > prevLevel.current;
-    scale.value = leveledUp ? 1.8 : 1.4;
-    rotate.value = leveledUp ? 15 : 0;
-    scale.value = withTiming(1, { duration: 300 });
-    rotate.value = withTiming(0, { duration: 300 });
-
     if (leveledUp) {
+      scale.value = 1.8;
+      rotate.value = 15;
+      scale.value = withTiming(1, { duration: 300 });
+      rotate.value = withTiming(0, { duration: 300 });
       successNotification();
     }
     prevLevel.current = level;

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -139,7 +139,6 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
 
     const prevState = useRecycleBinStore.getState();
     const prevXp = prevState.xp;
-    const prevTotal = prevState.totalDeleted;
 
     addDeletedPhoto(deletedPhoto); // XP assignment happens in the store
     // Play a random voice clip for extra feedback
@@ -147,12 +146,12 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     // Keep count of deletes to occasionally show surprise messages
     deleteCountRef.current += 1;
 
-    const { xp: newXp, totalDeleted: newTotal } = useRecycleBinStore.getState();
+    const { xp: newXp } = useRecycleBinStore.getState();
     const prevLevel = Math.floor(prevXp / 100) + 1;
     const newLevel = Math.floor(newXp / 100) + 1;
 
-    // Combo check and level-up trigger
-    if (newLevel > prevLevel || newTotal % 50 === 0) {
+    // Trigger confetti only on level ups to keep it special
+    if (newLevel > prevLevel) {
       setConfettiKey((k) => k + 1);
     }
 


### PR DESCRIPTION
## Summary
- show confetti only when leveling up
- animate XP widget only on level up
- update README about confetti behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a90c41f04832b8206bc8516dd7a83