### PR TITLE
Enhance feedback with tap sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It features a small bird mascot inspired by **Flappy Bird** that celebrates your
 2. The Inter font and a retro "Press Start 2P" font are bundled and load automatically on startup. Update `lib/useCustomFonts.ts` and `tailwind.config.js` if you prefer different typefaces.
 3. Add sound effects by following the instructions in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 4. (Optional) Place a music file at `assets/music/background.mp3` to enable looping background music. The app starts this track automatically.
-5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep.
+5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep. A short `tap.mp3` adds feedback on button presses.
 6. For a nostalgic feel, pick short 8-bit style clips reminiscent of retro Nintendo games. A confetti burst celebrates each level up.
 7. The `audioService` will load these sounds automatically and handle failures gracefully.
 8. Subtle haptic feedback triggers on each swipe for extra game feel.

--- a/__tests__/audioService.test.ts
+++ b/__tests__/audioService.test.ts
@@ -46,7 +46,7 @@ beforeEach(async () => {
 test('initialize loads players with stored volume', async () => {
   memory['decluttr_audio_settings'] = JSON.stringify({ volume: 0.5, enabled: true });
   await audioService.initialize();
-  expect(createAudioPlayer).toHaveBeenCalledTimes(4);
+  expect(createAudioPlayer).toHaveBeenCalledTimes(5);
   const players = (createAudioPlayer as jest.Mock).mock.results.map((r) => r.value as any);
   expect(players[0].volume).toBe(0.5);
   expect(players[1].volume).toBe(0.5);
@@ -63,7 +63,7 @@ test('plays delete and keep sounds when enabled', async () => {
   expect(players[1].seekTo).toHaveBeenCalledWith(0);
   expect(players[1].play).toHaveBeenCalled();
   // voice clips are loaded as well
-  expect(createAudioPlayer).toHaveBeenCalledTimes(4);
+  expect(createAudioPlayer).toHaveBeenCalledTimes(5);
 });
 
 test('setVolume updates players and storage', async () => {
@@ -80,10 +80,10 @@ test('setVolume updates players and storage', async () => {
 test('cleanup removes players and allows reinit', async () => {
   await audioService.initialize();
   await audioService.cleanup();
-  expect(createAudioPlayer).toHaveBeenCalledTimes(4);
+  expect(createAudioPlayer).toHaveBeenCalledTimes(5);
   jest.clearAllMocks();
   await audioService.playDeleteSound();
-  expect(createAudioPlayer).toHaveBeenCalledTimes(4); // reinitializes
+  expect(createAudioPlayer).toHaveBeenCalledTimes(5); // reinitializes
 });
 
 test('playRandomVoice plays one clip when enabled', async () => {
@@ -91,6 +91,6 @@ test('playRandomVoice plays one clip when enabled', async () => {
   await audioService.playRandomVoice();
   await new Promise((r) => setTimeout(r, 350));
   const players = (createAudioPlayer as jest.Mock).mock.results.map((r) => r.value as any);
-  const plays = players.slice(2).map((p: any) => p.play.mock.calls.length);
+  const plays = players.slice(3).map((p: any) => p.play.mock.calls.length);
   expect(plays[0] + plays[1]).toBe(1);
 });

--- a/assets/sounds/README.md
+++ b/assets/sounds/README.md
@@ -12,6 +12,7 @@ These sample clips are short (~0.5–1s) MP3s. Replace them with your own before
 ## Optional Files
 
 - `voice1.mp3` and `voice2.mp3` - short voice clips that occasionally play after deleting a photo
+- `tap.mp3` - quick blip that plays when tapping buttons
 
 The included files are silent placeholders. Provide your own voice clips to use this feature.
 

--- a/assets/sounds/SETUP_INSTRUCTIONS.md
+++ b/assets/sounds/SETUP_INSTRUCTIONS.md
@@ -40,7 +40,7 @@ Use built-in Android system sounds:
 ## Quick Setup:
 
 1. Place MP3 files in this directory
-2. Name them exactly: `delete.mp3` and `keep.mp3`
+2. Name them exactly: `delete.mp3`, `keep.mp3` and (optionally) `tap.mp3`
 3. App will automatically detect and use them
 4. If files are missing, audio will fail gracefully without errors
 

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { View, Dimensions } from 'react-native';
+import { View, Dimensions, PixelRatio } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -10,6 +10,8 @@ import { SwipeCard } from './SwipeCard';
 import { cn } from '~/lib/cn';
 
 const { width: screenWidth } = Dimensions.get('window');
+const DECK_WIDTH = PixelRatio.roundToNearestPixel(screenWidth * 0.9);
+const DECK_HEIGHT = PixelRatio.roundToNearestPixel(screenWidth * 1.2);
 
 export interface SwipeDeckItem {
   id: string;
@@ -199,8 +201,8 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
       <View
         className={cn('items-center justify-center', className)}
         style={{
-          width: screenWidth * 0.9,
-          height: screenWidth * 1.2,
+          width: DECK_WIDTH,
+          height: DECK_HEIGHT,
         }}></View>
     );
   }
@@ -209,8 +211,8 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
     <View
       className={cn('items-center justify-center', className)}
       style={{
-        width: screenWidth * 0.9,
-        height: screenWidth * 1.2,
+        width: DECK_WIDTH,
+        height: DECK_HEIGHT,
       }}>
       {visibleCards.map((card) => {
         const isTopCard = card.stackIndex === 0;

--- a/lib/useSwipeAudio.ts
+++ b/lib/useSwipeAudio.ts
@@ -40,8 +40,13 @@ export const useSwipeAudio = () => {
     lightImpact();
   };
 
+  const playTapSound = () => {
+    audioService.playTapSound();
+  };
+
   return {
     playDeleteSound,
     playKeepSound,
+    playTapSound,
   };
 };


### PR DESCRIPTION
## Summary
- add optional `tap.mp3` sound
- support tap sound in `audioService` and hook
- scale buttons and play tap audio on press
- round swipe deck dimensions to the nearest pixel
- update docs and tests

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685a939f9e94832b939bcf02087fab2f