### PR TITLE
Improve Android swipe experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Minimal photo clean-up game built with Expo React Native.
 It features a small bird mascot inspired by **Flappy Bird** that celebrates your progress.
 **Android only** – other platforms are not supported.
+The interface now uses pixel-perfect scaling and preloaded sounds for
+immediate feedback when swiping photos.
 
 ## Prerequisites
 
@@ -92,6 +94,7 @@ For more details on specific systems see:
 - `ONBOARDING_README.md`
 - `XP_SYSTEM_README.md`
 - `MASCOT_README.md`
+- `lib/pixelPerfect.ts` explains the `px()` helper used for pixel-accurate layout.
 
 ## Testing
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ import { useColorScheme, useInitialAndroidBarSync } from '~/lib/useColorScheme';
 import { useRecycleBinStore } from '~/store/store';
 import { useCustomFonts } from '~/lib/useCustomFonts';
 import { backgroundMusicService } from '~/lib/backgroundMusic';
+import { audioService } from '~/lib/audioService';
 import { NAV_THEME } from '~/theme';
 
 export function ErrorBoundary({ error }: { error: Error }) {
@@ -63,6 +64,7 @@ export default function RootLayout() {
   useEffect(() => {
     if (fontsLoaded && isXpLoaded) {
       backgroundMusicService.play();
+      audioService.initialize().catch(() => {});
     }
     return () => {
       backgroundMusicService.stop();

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Image, Dimensions, PixelRatio } from 'react-native';
+import { View, Image, Dimensions } from 'react-native';
 import { PanGestureHandler, PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedGestureHandler,
@@ -12,11 +12,12 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useSwipeAudio } from '~/lib/useSwipeAudio';
+import { px } from '~/lib/pixelPerfect';
 
 const { width: screenWidth } = Dimensions.get('window');
-const CARD_WIDTH = PixelRatio.roundToNearestPixel(screenWidth * 0.7);
-const CARD_HEIGHT = PixelRatio.roundToNearestPixel(screenWidth * 0.8);
-const BORDER_RADIUS = PixelRatio.roundToNearestPixel(20);
+const CARD_WIDTH = px(screenWidth * 0.7);
+const CARD_HEIGHT = px(screenWidth * 0.8);
+const BORDER_RADIUS = px(20);
 // Slightly easier swipe threshold for smoother feel
 const SWIPE_THRESHOLD = screenWidth * 0.25;
 
@@ -133,7 +134,12 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   });
 
   return (
-    <PanGestureHandler onGestureEvent={gestureHandler} enabled={!disabled}>
+    <PanGestureHandler
+      onGestureEvent={gestureHandler}
+      enabled={!disabled}
+      activeOffsetX={[-10, 10]}
+      failOffsetY={[-10, 10]}
+      shouldCancelWhenOutside={false}>
       <Animated.View
         style={[
           {

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { View, Dimensions, PixelRatio } from 'react-native';
+import { View, Dimensions } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -9,9 +9,11 @@ import Animated, {
 import { SwipeCard } from './SwipeCard';
 import { cn } from '~/lib/cn';
 
+import { px } from '~/lib/pixelPerfect';
+
 const { width: screenWidth } = Dimensions.get('window');
-const DECK_WIDTH = PixelRatio.roundToNearestPixel(screenWidth * 0.9);
-const DECK_HEIGHT = PixelRatio.roundToNearestPixel(screenWidth * 1.2);
+const DECK_WIDTH = px(screenWidth * 0.9);
+const DECK_HEIGHT = px(screenWidth * 1.2);
 
 export interface SwipeDeckItem {
   id: string;

--- a/lib/pixelPerfect.ts
+++ b/lib/pixelPerfect.ts
@@ -1,0 +1,9 @@
+import { PixelRatio } from 'react-native';
+
+/**
+ * Convert a design measurement to the closest pixel.
+ * Helps achieve crisp UI on all screen densities.
+ */
+export function px(size: number): number {
+  return PixelRatio.roundToNearestPixel(size);
+}


### PR DESCRIPTION
## Summary
- add `px()` helper for pixel-accurate sizing
- use `px()` in swipe components
- tweak gesture settings for smoother swipes
- preload audio on app startup
- document pixel scaling utility

## Testing
- `npm install`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a95b7291c832b80b5267115dee706