### PR TITLE
Enhance swipe feedback and pixel precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Minimal photo clean-up game built with Expo React Native.
 It features a small bird mascot inspired by **Flappy Bird** that celebrates your progress.
 **Android only** – other platforms are not supported.
 The interface now uses pixel-perfect scaling and preloaded sounds for
-immediate feedback when swiping photos.
+immediate feedback when swiping photos. Swipes trigger a short tap sound right
+as you start dragging so the game feels instantly responsive.
 
 ## Prerequisites
 

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -1,5 +1,6 @@
 import { Feather } from '@expo/vector-icons';
 import { Text, View, StyleSheet } from 'react-native';
+import { px } from '~/lib/pixelPerfect';
 
 export const BackButton = ({ onPress }: { onPress: () => void }) => {
   return (
@@ -14,10 +15,10 @@ export const BackButton = ({ onPress }: { onPress: () => void }) => {
 const styles = StyleSheet.create({
   backButton: {
     flexDirection: 'row',
-    paddingLeft: 20,
+    paddingLeft: px(20),
   },
   backButtonText: {
     color: '#007AFF',
-    marginLeft: 4,
+    marginLeft: px(4),
   },
 });

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+import { px } from '~/lib/pixelPerfect';
 
 type ButtonProps = {
   title?: string;
@@ -19,11 +20,11 @@ const styles = StyleSheet.create({
   button: {
     alignItems: 'center',
     backgroundColor: '#6366F1',
-    borderRadius: 24,
+    borderRadius: px(24),
     elevation: 5,
     flexDirection: 'row',
     justifyContent: 'center',
-    padding: 16,
+    padding: px(16),
     shadowColor: '#000',
     shadowOffset: {
       height: 2,

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -1,4 +1,5 @@
 import { StyleSheet, SafeAreaView } from 'react-native';
+import { px } from '~/lib/pixelPerfect';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;
@@ -7,6 +8,6 @@ export const Container = ({ children }: { children: React.ReactNode }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 18,
+    padding: px(18),
   },
 });

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -39,12 +39,13 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
-  const { playDeleteSound, playKeepSound } = useSwipeAudio();
+  const { playDeleteSound, playKeepSound, playTapSound } = useSwipeAudio();
 
   const gestureHandler = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
     onStart: () => {
       if (!disabled) {
         scale.value = withSpring(0.8);
+        runOnJS(playTapSound)();
       }
     },
     onActive: (event) => {
@@ -137,8 +138,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     <PanGestureHandler
       onGestureEvent={gestureHandler}
       enabled={!disabled}
-      activeOffsetX={[-10, 10]}
-      failOffsetY={[-10, 10]}
+      activeOffsetX={[-5, 5]}
+      failOffsetY={[-5, 5]}
       shouldCancelWhenOutside={false}>
       <Animated.View
         style={[


### PR DESCRIPTION
## Summary
- use `px()` helper across core components for crisp UI
- play tap sound and lighten gesture thresholds for smoother swipes
- document improved responsiveness in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a98770e70832b9f936f41188da5b2