### PR TITLE
Improve tactile feedback and font scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Minimal photo clean-up game built with Expo React Native.
 It features a small bird mascot inspired by **Flappy Bird** that celebrates your progress.
 **Android only** – other platforms are not supported.
-The interface now uses pixel-perfect scaling and preloaded sounds for
-immediate feedback when swiping photos. Swipes trigger a short tap sound right
+The interface now uses pixel-perfect fonts and preloaded sounds for
+immediate feedback when swiping photos. Swipes trigger a short tap sound and light haptic right
 as you start dragging so the game feels instantly responsive.
 
 ## Prerequisites

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -19,7 +19,7 @@ const CARD_WIDTH = px(screenWidth * 0.7);
 const CARD_HEIGHT = px(screenWidth * 0.8);
 const BORDER_RADIUS = px(20);
 // Slightly easier swipe threshold for smoother feel
-const SWIPE_THRESHOLD = screenWidth * 0.25;
+const SWIPE_THRESHOLD = screenWidth * 0.2;
 
 export interface SwipeCardProps {
   imageUri: string;
@@ -44,14 +44,14 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   const gestureHandler = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
     onStart: () => {
       if (!disabled) {
-        scale.value = withSpring(0.8);
+        scale.value = withSpring(0.95);
         runOnJS(playTapSound)();
       }
     },
     onActive: (event) => {
       if (!disabled) {
         translateX.value = event.translationX;
-        translateY.value = event.translationY * 0.1; // Reduce vertical movement
+        translateY.value = event.translationY * 0.05; // Reduce vertical movement
       }
     },
     onEnd: (event) => {
@@ -138,8 +138,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     <PanGestureHandler
       onGestureEvent={gestureHandler}
       enabled={!disabled}
-      activeOffsetX={[-5, 5]}
-      failOffsetY={[-5, 5]}
+      activeOffsetX={[-8, 8]}
+      failOffsetY={[-8, 8]}
       shouldCancelWhenOutside={false}>
       <Animated.View
         style={[

--- a/components/nativewindui/Text.tsx
+++ b/components/nativewindui/Text.tsx
@@ -2,6 +2,7 @@ import { VariantProps, cva } from 'class-variance-authority';
 import { cssInterop } from 'nativewind';
 import * as React from 'react';
 import { UITextView } from 'react-native-uitextview';
+import { px } from '~/lib/pixelPerfect';
 
 import { cn } from '~/lib/cn';
 
@@ -10,17 +11,17 @@ cssInterop(UITextView, { className: 'style' });
 const textVariants = cva('text-foreground', {
   variants: {
     variant: {
-      largeTitle: 'text-4xl leading-10',
-      title1: 'text-2xl leading-8',
-      title2: 'text-[22px] leading-7',
-      title3: 'text-xl leading-7',
-      heading: 'text-[17px] leading-6 font-semibold',
-      body: 'text-[17px] leading-6',
-      callout: 'text-base leading-6',
-      subhead: 'text-[15px] leading-6',
-      footnote: 'text-[13px] leading-5',
-      caption1: 'text-xs leading-4',
-      caption2: 'text-[11px] leading-4',
+      largeTitle: 'leading-10',
+      title1: 'leading-8',
+      title2: 'leading-7',
+      title3: 'leading-7',
+      heading: 'leading-6 font-semibold',
+      body: 'leading-6',
+      callout: 'leading-6',
+      subhead: 'leading-6',
+      footnote: 'leading-5',
+      caption1: 'leading-4',
+      caption2: 'leading-4',
     },
     color: {
       primary: '',
@@ -35,6 +36,20 @@ const textVariants = cva('text-foreground', {
   },
 });
 
+const fontSizes = {
+  largeTitle: px(34),
+  title1: px(28),
+  title2: px(22),
+  title3: px(20),
+  heading: px(17),
+  body: px(17),
+  callout: px(16),
+  subhead: px(15),
+  footnote: px(13),
+  caption1: px(12),
+  caption2: px(11),
+} as const;
+
 // Use a clean sans-serif font by default for a modern look
 const TextClassContext = React.createContext<string | undefined>('font-sans');
 
@@ -45,9 +60,11 @@ function Text({
   ...props
 }: React.ComponentPropsWithoutRef<typeof UITextView> & VariantProps<typeof textVariants>) {
   const textClassName = React.useContext(TextClassContext);
+  const fontSize = fontSizes[(variant as keyof typeof fontSizes) ?? 'body'];
   return (
     <UITextView
       className={cn(textVariants({ variant, color }), textClassName, className)}
+      style={[{ fontSize }, props.style]}
       {...props}
     />
   );

--- a/lib/useSwipeAudio.ts
+++ b/lib/useSwipeAudio.ts
@@ -42,6 +42,7 @@ export const useSwipeAudio = () => {
 
   const playTapSound = () => {
     audioService.playTapSound();
+    lightImpact();
   };
 
   return {


### PR DESCRIPTION
## Summary
- use pixel-accurate font sizes via `px()` in Text component
- soften card interactions for smoother swipes
- trigger light haptic on tap for instant feedback
- update intro to mention haptic tap feedback

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a9ebed5dc832bbbbcb2e2f0c69b78