### PR TITLE
Enhance swipe experience

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { View, Alert, Dimensions, Pressable } from 'react-native';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
+import { XPToast } from './XPToast';
 import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
 import { cn } from '~/lib/cn';
-import { useRecycleBinStore, DeletedPhoto } from '~/store/store';
+import { useRecycleBinStore, DeletedPhoto, XP_CONFIG } from '~/store/store';
 import {
   SESSION_MESSAGES,
   END_MESSAGES,
@@ -49,6 +50,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
   const prefetchCursorRef = React.useRef<string | undefined>(undefined);
   const [hasMore, setHasMore] = useState(true);
   const [confettiKey, setConfettiKey] = useState(0);
+  const [xpToast, setXpToast] = useState<number | null>(null);
   const tapTimesRef = React.useRef<number[]>([]);
   // Track total deletes this session for surprise messages
   const deleteCountRef = React.useRef(0);
@@ -141,6 +143,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     const prevXp = prevState.xp;
 
     addDeletedPhoto(deletedPhoto); // XP assignment happens in the store
+    setXpToast(XP_CONFIG.DELETE_PHOTO);
     // Play a random voice clip for extra feedback
     audioService.playRandomVoice();
     // Keep count of deletes to occasionally show surprise messages
@@ -354,6 +357,10 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         maxVisibleCards={3}
         cardSpacing={12}
       />
+
+      {xpToast && (
+        <XPToast amount={xpToast} onDone={() => setXpToast(null)} />
+      )}
 
       {/* Confetti burst when deleting */}
       {confettiKey > 0 && (

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -19,7 +19,7 @@ const CARD_WIDTH = px(screenWidth * 0.7);
 const CARD_HEIGHT = px(screenWidth * 0.8);
 const BORDER_RADIUS = px(20);
 // Slightly easier swipe threshold for smoother feel
-const SWIPE_THRESHOLD = px(screenWidth * 0.2);
+const SWIPE_THRESHOLD = px(screenWidth * 0.15);
 
 export interface SwipeCardProps {
   imageUri: string;
@@ -66,11 +66,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       if (shouldSwipeLeft) {
         // Swipe left - delete
         translateX.value = withTiming(-px(screenWidth * 1.5), {
-          duration: 250,
+          duration: 180,
           easing: Easing.out(Easing.cubic),
         });
         translateY.value = withTiming(px(0), {
-          duration: 250,
+          duration: 180,
           easing: Easing.out(Easing.cubic),
         });
         // Play delete sound and trigger callback
@@ -81,11 +81,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       } else if (shouldSwipeRight) {
         // Swipe right - keep
         translateX.value = withTiming(px(screenWidth * 1.5), {
-          duration: 250,
+          duration: 180,
           easing: Easing.out(Easing.cubic),
         });
         translateY.value = withTiming(px(0), {
-          duration: 250,
+          duration: 180,
           easing: Easing.out(Easing.cubic),
         });
         // Play keep sound and trigger callback

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -124,7 +124,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
     }
     blockTimeoutRef.current = setTimeout(() => {
       setInputBlocked(false);
-    }, 300);
+    }, 150);
     const timeout = setTimeout(() => {
       setCurrentIndex((prevIndex) => {
         const nextIndex = prevIndex + 1;
@@ -135,7 +135,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
       });
       // remove finished timeout reference
       timeoutsRef.current = timeoutsRef.current.filter((t) => t !== timeout);
-    }, 300);
+    }, 150);
     timeoutsRef.current.push(timeout);
   }, [data.length, onDeckEmpty]);
 

--- a/components/XPToast.tsx
+++ b/components/XPToast.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+import { px } from '~/lib/pixelPerfect';
+
+interface XPToastProps {
+  amount: number;
+  onDone?: () => void;
+}
+
+export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
+  const opacity = useSharedValue(0);
+  const translateY = useSharedValue(px(20));
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration: 100 });
+    translateY.value = withTiming(0, { duration: 100 });
+
+    const timeout = setTimeout(() => {
+      opacity.value = withTiming(0, { duration: 300 }, () => {
+        if (onDone) {
+          runOnJS(onDone)();
+        }
+      });
+    }, 600);
+
+    return () => clearTimeout(timeout);
+  }, [onDone, opacity, translateY]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          position: 'absolute',
+          top: px(80),
+          alignSelf: 'center',
+          paddingHorizontal: px(8),
+          paddingVertical: px(4),
+          backgroundColor: 'rgba(0,0,0,0.7)',
+          borderRadius: px(4),
+        },
+        style,
+      ]}
+      pointerEvents="none"
+    >
+      <Text className="font-arcade text-white">+{amount} XP</Text>
+    </Animated.View>
+  );
+};


### PR DESCRIPTION
## Summary
- tweak SwipeCard to use a lower swipe threshold and faster animations
- shorten SwipeDeck input cooldown for quicker swiping
- show a small `XPToast` when deleting a photo

## Testing
- `npm install --silent`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa5ae3904832bbcf33806e030b000