### PR TITLE
Add level header and XP toast bounce

### DIFF
--- a/components/LevelHeader.tsx
+++ b/components/LevelHeader.tsx
@@ -1,0 +1,46 @@
+import React, { useRef, useEffect } from 'react';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
+import { useRecycleBinStore } from '~/store/store';
+import { cn } from '~/lib/cn';
+
+interface LevelHeaderProps {
+  className?: string;
+}
+
+export const LevelHeader: React.FC<LevelHeaderProps> = ({ className }) => {
+  const { xp } = useRecycleBinStore();
+  const scale = useSharedValue(1);
+  const prevLevel = useRef(Math.floor(xp / 100) + 1);
+
+  const level = Math.floor(xp / 100) + 1;
+  const progress = xp % 100;
+
+  useEffect(() => {
+    const leveledUp = level > prevLevel.current;
+    if (leveledUp) {
+      scale.value = 1.3;
+      scale.value = withTiming(1, { duration: 300 });
+    }
+    prevLevel.current = level;
+  }, [level, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={animatedStyle}
+      className={cn(
+        'items-center rounded-full bg-[rgb(var(--android-xp)/0.2)] px-3 py-1 dark:bg-[rgb(var(--android-xp)/0.3)]',
+        className
+      )}>
+      <Text className="font-arcade text-xs text-[rgb(var(--android-xp))]">
+        ⭐ Lv {level} • {xp} XP
+      </Text>
+      <ProgressIndicator value={progress} className="mt-1 bg-[rgb(var(--android-xp))]" />
+    </Animated.View>
+  );
+};

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -3,6 +3,7 @@ import { View, Alert, Dimensions, Pressable } from 'react-native';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
 import { XPToast } from './XPToast';
+import { LevelHeader } from './LevelHeader';
 import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
@@ -328,6 +329,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     <Pressable
       onPress={handleDebugTap}
       className={cn('flex-1 items-center justify-center', className)}>
+      <LevelHeader className="mb-6" />
       {/* Stats displayed as progress bars */}
       <View className="mb-6 w-3/4 space-y-2">
         <View>
@@ -367,9 +369,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         cardSpacing={12}
       />
 
-      {xpToast && (
-        <XPToast amount={xpToast} onDone={() => setXpToast(null)} />
-      )}
+      {xpToast && <XPToast amount={xpToast} onDone={() => setXpToast(null)} />}
 
       {/* Confetti burst when deleting */}
       {confettiKey > 0 && (

--- a/components/XPToast.tsx
+++ b/components/XPToast.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import { View } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  withSpring,
   runOnJS,
 } from 'react-native-reanimated';
 import { Text } from '~/components/nativewindui/Text';
@@ -17,10 +17,12 @@ interface XPToastProps {
 export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(px(20));
+  const scale = useSharedValue(0.6);
 
   useEffect(() => {
     opacity.value = withTiming(1, { duration: 100 });
     translateY.value = withTiming(0, { duration: 100 });
+    scale.value = withSpring(1, { damping: 8, stiffness: 200 });
 
     const timeout = setTimeout(() => {
       opacity.value = withTiming(0, { duration: 300 }, () => {
@@ -31,11 +33,11 @@ export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
     }, 600);
 
     return () => clearTimeout(timeout);
-  }, [onDone, opacity, translateY]);
+  }, [onDone, opacity, translateY, scale]);
 
   const style = useAnimatedStyle(() => ({
     opacity: opacity.value,
-    transform: [{ translateY: translateY.value }],
+    transform: [{ translateY: translateY.value }, { scale: scale.value }],
   }));
 
   return (
@@ -52,8 +54,7 @@ export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
         },
         style,
       ]}
-      pointerEvents="none"
-    >
+      pointerEvents="none">
       <Text className="font-arcade text-white">+{amount} XP</Text>
     </Animated.View>
   );


### PR DESCRIPTION
## Summary
- show a level header with an XP-colored progress bar in the photo gallery
- pop XP toast with a spring bounce effect

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ab7ca5fac832b82c659f7c950f277