### PR TITLE
Enhance swipe responsiveness

### DIFF
--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -21,6 +21,8 @@ const BORDER_RADIUS = px(20);
 // Slightly easier swipe threshold for smoother feel
 // Reduce the swipe threshold slightly so cards respond quicker
 const SWIPE_THRESHOLD = px(screenWidth * 0.12);
+// Faster exit animation for snappier feedback
+const SWIPE_EXIT_DURATION = 120;
 
 export interface SwipeCardProps {
   imageUri: string;
@@ -67,11 +69,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       if (shouldSwipeLeft) {
         // Swipe left - delete
         translateX.value = withTiming(-px(screenWidth * 1.5), {
-          duration: 160,
+          duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
         translateY.value = withTiming(px(0), {
-          duration: 160,
+          duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
         // Play delete sound and trigger callback
@@ -82,11 +84,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       } else if (shouldSwipeRight) {
         // Swipe right - keep
         translateX.value = withTiming(px(screenWidth * 1.5), {
-          duration: 160,
+          duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
         translateY.value = withTiming(px(0), {
-          duration: 160,
+          duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
         // Play keep sound and trigger callback
@@ -139,8 +141,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     <PanGestureHandler
       onGestureEvent={gestureHandler}
       enabled={!disabled}
-      activeOffsetX={[-8, 8]}
-      failOffsetY={[-8, 8]}
+      activeOffsetX={[-6, 6]}
+      failOffsetY={[-6, 6]}
       shouldCancelWhenOutside={false}>
       <Animated.View
         style={[

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -14,6 +14,8 @@ import { px } from '~/lib/pixelPerfect';
 const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
+// Delay before the next card becomes interactive
+const ADVANCE_DELAY = 100;
 
 export interface SwipeDeckItem {
   id: string;
@@ -124,7 +126,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
     }
     blockTimeoutRef.current = setTimeout(() => {
       setInputBlocked(false);
-    }, 120);
+    }, ADVANCE_DELAY);
     const timeout = setTimeout(() => {
       setCurrentIndex((prevIndex) => {
         const nextIndex = prevIndex + 1;
@@ -135,7 +137,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
       });
       // remove finished timeout reference
       timeoutsRef.current = timeoutsRef.current.filter((t) => t !== timeout);
-    }, 120);
+    }, ADVANCE_DELAY);
     timeoutsRef.current.push(timeout);
   }, [data.length, onDeckEmpty]);
 


### PR DESCRIPTION
## Summary
- shorten swipe animation duration for faster feedback
- reduce gesture offset detection
- let deck advance quicker after each swipe

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685abc3877d0832ba12b5debdedc9df0