### PR TITLE
Tune swipe interactions

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -10,6 +10,7 @@ import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
 import { cn } from '~/lib/cn';
+import { px } from '~/lib/pixelPerfect';
 import { useRecycleBinStore, DeletedPhoto, XP_CONFIG } from '~/store/store';
 import {
   SESSION_MESSAGES,
@@ -366,7 +367,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         onSwipeRight={handleSwipeRight}
         onDeckEmpty={handleDeckEmpty}
         maxVisibleCards={3}
-        cardSpacing={12}
+        cardSpacing={px(12)}
       />
 
       {xpToast && <XPToast amount={xpToast} onDone={() => setXpToast(null)} />}

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -18,11 +18,12 @@ const { width: screenWidth } = Dimensions.get('window');
 const CARD_WIDTH = px(screenWidth * 0.7);
 const CARD_HEIGHT = px(screenWidth * 0.8);
 const BORDER_RADIUS = px(20);
-// Slightly easier swipe threshold for smoother feel
-// Reduce the swipe threshold slightly so cards respond quicker
-const SWIPE_THRESHOLD = px(screenWidth * 0.12);
-// Faster exit animation for snappier feedback
-const SWIPE_EXIT_DURATION = 120;
+// Reduced threshold so even short drags register quickly
+const SWIPE_THRESHOLD = px(screenWidth * 0.1);
+// Shorter exit animation for snappier feedback
+const SWIPE_EXIT_DURATION = 100;
+// Expand touch area to make starting swipes easier
+const HIT_SLOP = px(16);
 
 export interface SwipeCardProps {
   imageUri: string;
@@ -143,7 +144,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       enabled={!disabled}
       activeOffsetX={[-6, 6]}
       failOffsetY={[-6, 6]}
-      shouldCancelWhenOutside={false}>
+      shouldCancelWhenOutside={false}
+      hitSlop={{ horizontal: HIT_SLOP, vertical: HIT_SLOP }}>
       <Animated.View
         style={[
           {

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -15,7 +15,7 @@ const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
 // Delay before the next card becomes interactive
-const ADVANCE_DELAY = 100;
+const ADVANCE_DELAY = 50;
 
 export interface SwipeDeckItem {
   id: string;
@@ -265,12 +265,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
           </Animated.View>
         );
       })}
-      {inputBlocked && (
-        <View
-          pointerEvents="auto"
-          style={{ position: 'absolute', inset: 0 }}
-        />
-      )}
+      {inputBlocked && <View pointerEvents="auto" style={{ position: 'absolute', inset: 0 }} />}
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- make swipe threshold smaller and animation faster
- expand gesture hit slop for smoother swiping
- speed up deck card advance
- use pixel helper for spacing in gallery

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685abe158224832ba13011990013a2f4