### PR TITLE
Improve swipe feedback

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -19,6 +19,7 @@ import {
   createMessagePicker,
 } from '~/lib/positiveMessages';
 import { audioService } from '~/lib/audioService';
+import { successNotification } from '~/lib/haptics';
 
 const pickSessionMessage = createMessagePicker(SESSION_MESSAGES);
 const pickEndMessage = createMessagePicker(END_MESSAGES);
@@ -161,6 +162,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     // Trigger confetti on level ups or long delete streaks
     if (newLevel > prevLevel || consecutiveDeleteRef.current >= STREAK_THRESHOLD) {
       setConfettiKey((k) => k + 1);
+      successNotification();
       if (consecutiveDeleteRef.current >= STREAK_THRESHOLD) {
         consecutiveDeleteRef.current = 0;
       }

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -15,8 +15,9 @@ const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
 // Delay before the next card becomes interactive
-const ADVANCE_DELAY = 50;
-const STACK_DELAY = 60; // Faster stack animation for snappier feel
+// Shorter delays keep the deck feeling responsive
+const ADVANCE_DELAY = 30;
+const STACK_DELAY = 45; // Snappier stack animation
 
 export interface SwipeDeckItem {
   id: string;


### PR DESCRIPTION
## Summary
- shorten deck timing constants for faster feel
- play a success haptic when confetti fires

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685acf33a898832bbd0aef0b5d6e1683