### PR TITLE
Enhance swipe feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ the `patch-package` script can apply fixes to expo-audio.
 
 ## Swipe Cooldown and Test Mode
 
-A brief 0.3&nbsp;second input mask now blocks touches after each swipe so fast gestures register cleanly while the next card loads.
+A brief 0.15&nbsp;second input mask now blocks touches after each swipe so fast gestures register cleanly while the next card loads.
 Tap anywhere five times quickly to simulate a left swipe for debugging.
 
 ### Audio Fallback
 
 Sound playback can fail if audio files are missing or the device blocks audio initialization. When that happens a default chime is used instead. See `lib/audioService.ts` for implementation details.
 
-The audio service queues rapid playback requests so quick swipes never overlap. Each swipe sound waits about 0.3&nbsp;seconds before the next begins. Delete actions sometimes play one of two short voice clips for extra charm.
+The audio service queues rapid playback requests so quick swipes never overlap. Each swipe sound waits about 0.15&nbsp;seconds before the next begins. Delete actions sometimes play one of two short voice clips for extra charm.
 These clips are processed through the same queue so they won't overlap even if you swipe rapidly. To enable the clips, add `voice1.mp3` and `voice2.mp3` under `assets/sounds/` as described in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 
 ## Performance Tips

--- a/assets/sounds/SETUP_INSTRUCTIONS.md
+++ b/assets/sounds/SETUP_INSTRUCTIONS.md
@@ -15,8 +15,8 @@ You can use online generators or audio software:
 1. **Online Tone Generators**:
 
    - Generate simple beeps/tones at different frequencies
-   - For delete: Lower frequency (200-400 Hz), 0.3-0.5 seconds
-   - For keep: Higher frequency (600-1000 Hz), 0.3-0.5 seconds
+   - For delete: Lower frequency (200-400 Hz), 0.15-0.3 seconds
+   - For keep: Higher frequency (600-1000 Hz), 0.15-0.3 seconds
 
 2. **Audio Software** (Audacity, GarageBand, etc.):
    - Create simple sine wave tones
@@ -32,7 +32,7 @@ Use built-in Android system sounds:
 
 ## Recommended Sound Characteristics:
 
-- **delete.mp3**: Subtle "whoosh" or low-pitched "thud" (300-500ms)
+- **delete.mp3**: Subtle "whoosh" or low-pitched "thud" (150-300ms)
 - **keep.mp3**: Pleasant "ding" or "chime" (200-400ms)
 - Consider using short 8-bit style blips for a retro Nintendo vibe
 - Both should be normalized to -6dB to prevent loud playback

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -21,7 +21,7 @@ const BORDER_RADIUS = px(20);
 // Reduced threshold so even short drags register quickly
 const SWIPE_THRESHOLD = px(screenWidth * 0.1);
 // Shorter exit animation for snappier feedback
-const SWIPE_EXIT_DURATION = 80;
+const SWIPE_EXIT_DURATION = 60;
 const ICON_SIZE = px(36);
 const STROKE_WIDTH = px(3);
 const OVERLAY_PADDING = px(6);

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -15,8 +15,8 @@ const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
 // Delay before the next card becomes interactive
-const ADVANCE_DELAY = 50;
-const STACK_DELAY = 60; // Faster stack animation for snappier feel
+const ADVANCE_DELAY = 40;
+const STACK_DELAY = 40; // Faster stack animation for snappier feel
 
 export interface SwipeDeckItem {
   id: string;
@@ -39,7 +39,7 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
   onSwipeRight,
   onDeckEmpty,
   maxVisibleCards = 3,
-  cardSpacing = 8,
+  cardSpacing = px(8),
   className,
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -63,8 +63,8 @@ export const SwipeDeck: React.FC<SwipeDeckProps> = ({
   const scale1 = useSharedValue(0.95);
   const scale2 = useSharedValue(0.9);
   const translateY0 = useSharedValue(0);
-  const translateY1 = useSharedValue(8);
-  const translateY2 = useSharedValue(16);
+  const translateY1 = useSharedValue(px(8));
+  const translateY2 = useSharedValue(px(16));
   const opacity0 = useSharedValue(1);
   const opacity1 = useSharedValue(0.9);
   const opacity2 = useSharedValue(0.8);

--- a/lib/audioService.ts
+++ b/lib/audioService.ts
@@ -144,7 +144,7 @@ export class AudioService {
     } catch (error) {
       console.warn('Audio playback failed:', error);
     }
-    setTimeout(() => this.processQueue(), 300);
+    setTimeout(() => this.processQueue(), 150);
   }
 
   /**


### PR DESCRIPTION
## Summary
- tune swipe deck timing
- accelerate swipe card exit animation
- speed up audio queue processing
- mention shorter delays in docs
- update sound instructions for shorter clips

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acf33a898832bbd0aef0b5d6e1683