### PR TITLE
Fix px worklet usage

### DIFF
--- a/__tests__/pixelPerfect.test.ts
+++ b/__tests__/pixelPerfect.test.ts
@@ -1,14 +1,14 @@
-jest.mock('react-native', () => ({
-  PixelRatio: { roundToNearestPixel: jest.fn((v) => Math.round(v)) },
-}));
-
 import { px } from '../lib/pixelPerfect';
 import { PixelRatio } from 'react-native';
 
+jest.mock('react-native', () => ({
+  PixelRatio: { get: jest.fn(() => 2) },
+}));
+
 describe('px helper', () => {
   it('rounds to nearest pixel', () => {
-    jest.spyOn(PixelRatio, 'roundToNearestPixel').mockReturnValueOnce(5);
-    expect(px(5.2)).toBe(5);
-    expect(PixelRatio.roundToNearestPixel).toHaveBeenCalledWith(5.2);
+    // px should use the mocked pixel scale of 2
+    expect(px(5.2)).toBe(Math.round(5.2 * 2) / 2);
+    expect(PixelRatio.get).toHaveBeenCalled();
   });
 });

--- a/lib/pixelPerfect.ts
+++ b/lib/pixelPerfect.ts
@@ -1,9 +1,12 @@
 import { PixelRatio } from 'react-native';
 
+const pixelScale = PixelRatio.get();
+
 /**
  * Convert a design measurement to the closest pixel.
  * Helps achieve crisp UI on all screen densities.
  */
 export function px(size: number): number {
-  return PixelRatio.roundToNearestPixel(size);
+  'worklet';
+  return Math.round(size * pixelScale) / pixelScale;
 }


### PR DESCRIPTION
## Summary
- avoid calling `PixelRatio` on the UI thread by rewriting `px`
- update tests accordingly

## Testing
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685ada7e53d4832bb3a938a3fb77f8dc