### PR TITLE
Fix loadZenMode initialization

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -31,6 +31,17 @@ interface PhotoGalleryProps {
 export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
   const isMounted = React.useRef(true);
 
+  // Use RecycleBin store
+  const {
+    deletedPhotos,
+    totalDeleted,
+    addDeletedPhoto,
+    xp,
+    resetGallery: resetRecycleBinStore,
+    isXpLoaded,
+    loadZenMode,
+  } = useRecycleBinStore();
+
   useEffect(() => {
     return () => {
       isMounted.current = false;
@@ -65,17 +76,6 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     const timeout = setTimeout(() => setShowSwipeHint(false), 3000);
     return () => clearTimeout(timeout);
   }, []);
-
-  // Use RecycleBin store
-  const {
-    deletedPhotos,
-    totalDeleted,
-    addDeletedPhoto,
-    xp,
-    resetGallery: resetRecycleBinStore,
-    isXpLoaded,
-    loadZenMode,
-  } = useRecycleBinStore();
 
   const loadPhotos = React.useCallback(async (cursor?: string): Promise<boolean> => {
     try {


### PR DESCRIPTION
## Summary
- move loadZenMode hook destructuring above its usage in `PhotoGallery`
- remove duplicate store block

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685adbe24400832b9e7585a3c570bd5e