### PR TITLE
Fix progress indicator scaling

### DIFF
--- a/components/nativewindui/ProgressIndicator.tsx
+++ b/components/nativewindui/ProgressIndicator.tsx
@@ -40,10 +40,10 @@ const ProgressIndicator = React.forwardRef<
       progress.value = withSpring(value, { overshootClamping: true });
     }, [value, progress]);
 
-  const indicator = useAnimatedStyle(() => {
-    const width = interpolate(progress.value, [0, 100], [1, 100], Extrapolation.CLAMP);
-    return { width: `${width}%` };
-  });
+    const indicator = useAnimatedStyle(() => {
+      const width = interpolate(progress.value, [0, max], [1, 100], Extrapolation.CLAMP);
+      return { width: `${width}%` };
+    }, [max]);
 
     return (
       <View


### PR DESCRIPTION
## Summary
- fix `ProgressIndicator` to respect `max` value when calculating width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adf4ddaf8832baae841dc623635f2