### PR TITLE
Improve photo loading speed

### DIFF
--- a/__tests__/mediaLibrary.test.ts
+++ b/__tests__/mediaLibrary.test.ts
@@ -6,6 +6,7 @@ import {
   fetchAllPhotoAssets,
   getAssetInfo,
   deletePhotoAssets,
+  resetMediaLibraryPermissionCache,
 } from '../lib/mediaLibrary';
 
 jest.mock('expo-media-library', () => {
@@ -50,7 +51,10 @@ jest.mock('expo-media-library', () => {
 const MediaLibrary = require('expo-media-library');
 
 describe('mediaLibrary', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMediaLibraryPermissionCache();
+  });
 
   it('requests and checks permissions', async () => {
     const granted = await requestMediaLibraryPermission();

--- a/lib/mediaLibrary.ts
+++ b/lib/mediaLibrary.ts
@@ -1,5 +1,12 @@
 import * as MediaLibrary from 'expo-media-library';
 
+// Cache permission status to avoid extra async calls
+let permissionGrantedCache: boolean | null = null;
+
+export function resetMediaLibraryPermissionCache(): void {
+  permissionGrantedCache = null;
+}
+
 export interface PhotoAsset {
   id: string;
   uri: string;
@@ -12,9 +19,11 @@ export interface PhotoAsset {
 export async function requestMediaLibraryPermission(): Promise<boolean> {
   try {
     const { status } = await MediaLibrary.requestPermissionsAsync();
-    return status === 'granted';
+    permissionGrantedCache = status === 'granted';
+    return permissionGrantedCache;
   } catch (error) {
     console.error('Error requesting media library permission:', error);
+    permissionGrantedCache = false;
     return false;
   }
 }
@@ -24,11 +33,16 @@ export async function requestMediaLibraryPermission(): Promise<boolean> {
  * @returns Promise<boolean> - true if permission is granted, false otherwise
  */
 export async function checkMediaLibraryPermission(): Promise<boolean> {
+  if (permissionGrantedCache !== null) {
+    return permissionGrantedCache;
+  }
   try {
     const { status } = await MediaLibrary.getPermissionsAsync();
-    return status === 'granted';
+    permissionGrantedCache = status === 'granted';
+    return permissionGrantedCache;
   } catch (error) {
     console.error('Error checking media library permission:', error);
+    permissionGrantedCache = false;
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- cache Media Library permission status to reduce repeated async calls
- reset the cache between tests

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685ae28df614832b9b13a34d5eb33c88