### PR TITLE
Improve recycle bin error handling

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -59,10 +59,10 @@ describe('RecycleBin store', () => {
     const { addDeletedPhoto, permanentlyDelete, clearRecycleBin } = useRecycleBinStore.getState();
     addDeletedPhoto(createPhoto('1'));
     addDeletedPhoto(createPhoto('2'));
-    await permanentlyDelete('1');
+    await expect(permanentlyDelete('1')).resolves.toBe(true);
     expect(mediaLibrary.deletePhotoAsset).toHaveBeenCalledWith('1');
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
-    await clearRecycleBin();
+    await expect(clearRecycleBin()).resolves.toBe(true);
     expect(mediaLibrary.deletePhotoAssets).toHaveBeenCalledWith(['2']);
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
     expect(useRecycleBinStore.getState().xp).toBe(
@@ -75,7 +75,7 @@ describe('RecycleBin store', () => {
     addDeletedPhoto(createPhoto('1'));
     (mediaLibrary.deletePhotoAsset as jest.Mock).mockResolvedValueOnce(false);
 
-    await permanentlyDelete('1');
+    await expect(permanentlyDelete('1')).resolves.toBe(false);
 
     // Photo should remain because deletion failed
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
@@ -102,7 +102,7 @@ describe('RecycleBin store', () => {
     addDeletedPhoto(createPhoto('2'));
     (mediaLibrary.deletePhotoAssets as jest.Mock).mockResolvedValueOnce(false);
 
-    await clearRecycleBin();
+    await expect(clearRecycleBin()).resolves.toBe(false);
 
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(2);
     // XP should only reflect initial deletes

--- a/app/(tabs)/recycle-bin.tsx
+++ b/app/(tabs)/recycle-bin.tsx
@@ -122,11 +122,15 @@ export default function RecycleBin() {
   };
 
   const handlePermanentDelete = async (photoId: string) => {
-    await permanentlyDelete(photoId);
-    Alert.alert(
-      'Photo Deleted',
-      `The photo has been permanently deleted.\n\n⭐ +${XP_CONFIG.PERMANENT_DELETE} XP`
-    );
+    const success = await permanentlyDelete(photoId);
+    if (success) {
+      Alert.alert(
+        'Photo Deleted',
+        `The photo has been permanently deleted.\n\n⭐ +${XP_CONFIG.PERMANENT_DELETE} XP`
+      );
+    } else {
+      Alert.alert('Error', 'Failed to delete photo. Please try again.');
+    }
   };
 
   const handleClearAll = () => {
@@ -142,11 +146,15 @@ export default function RecycleBin() {
           style: 'destructive',
           onPress: async () => {
             const photosCount = deletedPhotos.length;
-            await clearRecycleBin();
-            Alert.alert(
-              'Recycle Bin Cleared',
-              `All photos have been permanently deleted.\n\n⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`
-            );
+            const success = await clearRecycleBin();
+            if (success) {
+              Alert.alert(
+                'Recycle Bin Cleared',
+                `All photos have been permanently deleted.\n\n⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`
+              );
+            } else {
+              Alert.alert('Error', 'Failed to clear recycle bin.');
+            }
           },
         },
       ]


### PR DESCRIPTION
## Summary
- return success flags from `permanentlyDelete` and `clearRecycleBin`
- surface errors in Recycle Bin screen if deletions fail
- update tests for new return values

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af1be4f04832ba07c3f2f98f325d5