### PR TITLE
Fix progress bar starting at 1%

### DIFF
--- a/components/nativewindui/ProgressIndicator.tsx
+++ b/components/nativewindui/ProgressIndicator.tsx
@@ -41,7 +41,7 @@ const ProgressIndicator = React.forwardRef<
     }, [value, progress]);
 
     const indicator = useAnimatedStyle(() => {
-      const width = interpolate(progress.value, [0, max], [1, 100], Extrapolation.CLAMP);
+      const width = interpolate(progress.value, [0, max], [0, 100], Extrapolation.CLAMP);
       return { width: `${width}%` };
     }, [max]);
 


### PR DESCRIPTION
## Summary
- fix ProgressIndicator so the bar starts at zero rather than 1%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af6b231f8832b8511c5f6673e9f50