### PR TITLE
Fix session stats reset when loading new batches

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -82,12 +82,10 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       if (!isMounted.current) return false;
       setLoading(true);
 
-      // Capture session start stats only when loading from the beginning
-      if (!(cursor ?? nextCursorRef.current)) {
-        const { xp: currentXp, deletedPhotos: currentDeleted } = useRecycleBinStore.getState();
-        setSessionStartXp(currentXp);
-        setSessionDeletedStart(currentDeleted.length);
-      }
+      // Capture session start stats for every new batch
+      const { xp: currentXp, deletedPhotos: currentDeleted } = useRecycleBinStore.getState();
+      setSessionStartXp(currentXp);
+      setSessionDeletedStart(currentDeleted.length);
 
       const result = await fetchPhotoAssetsWithPagination(cursor ?? nextCursorRef.current, 50);
       const photoItems: SwipeDeckItem[] = result.assets.map((asset) => ({
@@ -206,6 +204,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     if (hasMore) {
       // If a prefetched batch exists use it to avoid a loading pause
       if (prefetchedPhotos.length > 0) {
+        // New batch: record session start stats
+        const { xp: currentXp, deletedPhotos: currentDeleted } = useRecycleBinStore.getState();
+        setSessionStartXp(currentXp);
+        setSessionDeletedStart(currentDeleted.length);
+
         setPhotos(prefetchedPhotos);
         setPrefetchedPhotos([]);
         setKeptPhotos([]);


### PR DESCRIPTION
## Summary
- record XP and delete counts whenever loading a photo batch
- update session baseline when using prefetched photos

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af6b231f8832b8511c5f6673e9f50