### PR TITLE
Improve fonts docs and simplify UI

### DIFF
--- a/GAME_CUSTOMIZATION.md
+++ b/GAME_CUSTOMIZATION.md
@@ -3,8 +3,51 @@
 This guide summarizes the key files to modify when you want to personalize the game experience.
 
 ## Fonts and Typography
-- **`lib/useCustomFonts.ts`** – defines the Google Fonts loaded at runtime. Swap these imports with your preferred fonts and update the font names in `tailwind.config.js`.
-- **`tailwind.config.js`** – tailwind typography settings. Make sure the `fontFamily` section matches the fonts you load.
+
+DeCluttr ships with the classic arcade typeface **"Press Start 2P"** alongside Inter.
+The fonts are loaded with Expo's font utilities and exposed via Tailwind so you can
+easily reference them in your components.
+
+### Loading fonts
+
+- **`lib/useCustomFonts.ts`** imports `PressStart2P_400Regular` from
+  `@expo-google-fonts/press-start-2p` and passes it to `useFonts` together with the
+  other Google Fonts. The snippet below shows the relevant section:
+
+  ```ts
+  import { PressStart2P_400Regular } from '@expo-google-fonts/press-start-2p';
+
+  export function useCustomFonts() {
+    const [loaded] = useFonts({
+      Inter_400Regular,
+      Inter_700Bold,
+      PressStart2P_400Regular,
+      VT323_400Regular,
+      Bungee_400Regular,
+      UnifrakturCook_700Bold,
+    });
+    return loaded;
+  }
+  ```
+
+### Tailwind configuration
+
+- **`tailwind.config.js`** maps a `fontFamily` entry called `arcade` to
+  `"Press Start 2P"` so you can apply it with the class `font-arcade`:
+
+  ```js
+  fontFamily: {
+    sans: ['Inter', 'System', 'sans-serif'],
+    arcade: ['"Press Start 2P"', 'Inter', 'System', 'sans-serif'],
+    celeste: ['"VT323"', 'monospace'],
+    funky: ['"Bungee"', 'sans-serif'],
+    medieval: ['"UnifrakturCook"', 'serif'],
+  },
+  ```
+
+To use different fonts, install them from `@expo-google-fonts`, replace the imports
+in `lib/useCustomFonts.ts` and update the `fontFamily` entries in
+`tailwind.config.js` accordingly.
 
 ## Sounds
 - Place your own effects under `assets/sounds/` following `assets/sounds/SETUP_INSTRUCTIONS.md`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ give instant feedback as soon as you start swiping so the game feels snappy and 
    ```bash
    npm install && npx patch-package
    ```
-2. The Inter font and a retro "Press Start 2P" font are bundled and load automatically on startup. Update `lib/useCustomFonts.ts` and `tailwind.config.js` if you prefer different typefaces.
+2. The Inter font and a retro "Press Start 2P" font are bundled and load automatically on startup. See the **Fonts and Typography** section in `GAME_CUSTOMIZATION.md` for a code snippet showing how these fonts are loaded and how to swap them for alternatives.
 3. Add sound effects by following the instructions in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 4. (Optional) Place a music file at `assets/music/background.mp3` to enable looping background music. The app starts this track automatically.
 5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep.

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -67,21 +67,21 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         headerShown: true,
+        headerTitle: '',
         headerRight: () => <XPDisplay />,
+        tabBarShowLabel: false,
         tabBarActiveTintColor: '#007AFF',
         tabBarInactiveTintColor: '#8E8E93',
       }}>
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
           tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="recycle-bin"
         options={{
-          title: 'Recycle Bin',
           tabBarIcon: ({ color, size }) => <RecycleBinTabIcon color={color} size={size} />,
         }}
       />


### PR DESCRIPTION
## Summary
- expand documentation on using the "Press Start 2P" font
- point README to the new guide
- hide titles and labels in the tab layout for a cleaner look

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b03a0f62c832b9e97cd2daac49a81