### PR TITLE
Minimal retro UI tweaks

### DIFF
--- a/components/BackgroundOptimizer.tsx
+++ b/components/BackgroundOptimizer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Text } from '~/components/nativewindui/Text';
+import { px } from '~/lib/pixelPerfect';
+
+export const BackgroundOptimizer: React.FC = () => (
+  <View className="mt-4 flex-row items-center justify-center opacity-80">
+    <Ionicons
+      name="hardware-chip"
+      size={px(14)}
+      color="rgb(var(--android-muted-foreground))"
+    />
+    <Text className="ml-2 text-xs" color="secondary">
+      Optimizing in the background…
+    </Text>
+  </View>
+);

--- a/components/LevelHeader.tsx
+++ b/components/LevelHeader.tsx
@@ -34,13 +34,14 @@ export const LevelHeader: React.FC<LevelHeaderProps> = ({ className }) => {
     <Animated.View
       style={animatedStyle}
       className={cn(
-        'items-center rounded-full bg-[rgb(var(--android-xp)/0.2)] px-3 py-1 dark:bg-[rgb(var(--android-xp)/0.3)]',
+        'items-center rounded-2xl bg-[rgb(var(--android-card))] px-4 py-2 shadow-md dark:bg-[rgb(var(--android-card))]',
         className
       )}>
-      <Text className="font-arcade text-xs text-[rgb(var(--android-xp))]">
-        ⭐ Lv {level} • {xp} XP
-      </Text>
-      <ProgressIndicator value={progress} className="mt-1 bg-[rgb(var(--android-xp))]" />
+      <Text className="font-arcade text-lg text-[rgb(var(--android-primary))]">Lv {level}</Text>
+      <ProgressIndicator
+        value={progress}
+        className="mt-1 h-1 w-16 bg-[rgb(var(--android-primary))]"
+      />
     </Animated.View>
   );
-};
+}; 

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -5,6 +5,7 @@ import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
 import { XPToast } from './XPToast';
 import { LevelHeader } from './LevelHeader';
 import { SwipeHint } from './SwipeHint';
+import { BackgroundOptimizer } from './BackgroundOptimizer';
 import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
@@ -344,12 +345,6 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       onPress={handleDebugTap}
       className={cn('flex-1 items-center justify-center', className)}>
       <LevelHeader className="mb-6" />
-      {/* Swipe Instructions */}
-      <View className="mb-6 px-8">
-        <Text variant="subhead" color="secondary" className="text-center">
-          Swipe left to delete, right to keep
-        </Text>
-      </View>
 
       {/* Swipe Deck */}
       <SwipeDeck
@@ -381,6 +376,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
           <Text className="text-white">Reset Gallery & XP</Text>
         </Button>
       </View>
+      <BackgroundOptimizer />
     </Pressable>
   );
 };

--- a/global.css
+++ b/global.css
@@ -4,18 +4,18 @@
 
 @layer base {
   :root {
-    --background: 255 255 255;
-    --foreground: 0 0 0;
-    --card: 240 240 240;
-    --card-foreground: 0 0 0;
+    --background: 250 248 239;
+    --foreground: 119 110 101;
+    --card: 237 228 218;
+    --card-foreground: 119 110 101;
     --popover: 255 255 255;
     --popover-foreground: 0 0 0;
-    --primary: 0 0 0;
+    --primary: 119 110 101;
     --primary-foreground: 255 255 255;
-    --secondary: 0 0 0;
+    --secondary: 119 110 101;
     --secondary-foreground: 255 255 255;
-    --muted: 200 200 200;
-    --muted-foreground: 0 0 0;
+    --muted: 187 173 160;
+    --muted-foreground: 119 110 101;
     --accent: 120 120 120;
     --accent-foreground: 255 255 255;
     --destructive: 255 0 0;
@@ -25,18 +25,18 @@
     --input: 230 230 230;
     --ring: 120 120 120;
 
-    --android-background: 255 255 255;
-    --android-foreground: 0 0 0;
-    --android-card: 255 255 255;
-    --android-card-foreground: 0 0 0;
+    --android-background: 250 248 239;
+    --android-foreground: 119 110 101;
+    --android-card: 237 228 218;
+    --android-card-foreground: 119 110 101;
     --android-popover: 255 255 255;
     --android-popover-foreground: 0 0 0;
-    --android-primary: 0 0 0;
+    --android-primary: 119 110 101;
     --android-primary-foreground: 255 255 255;
-    --android-secondary: 0 0 0;
+    --android-secondary: 119 110 101;
     --android-secondary-foreground: 255 255 255;
-    --android-muted: 200 200 200;
-    --android-muted-foreground: 0 0 0;
+    --android-muted: 187 173 160;
+    --android-muted-foreground: 119 110 101;
     --android-accent: 120 120 120;
     --android-accent-foreground: 255 255 255;
     --android-destructive: 255 0 0;


### PR DESCRIPTION
## Summary
- update color palette for a 2048‐style look
- simplify level header tile
- remove swipe instruction text and show background optimization banner

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d01e9a81c832ba1f0822f69328120