### PR TITLE
Refine UI with retro style

### DIFF
--- a/app/(tabs)/recycle-bin.tsx
+++ b/app/(tabs)/recycle-bin.tsx
@@ -23,14 +23,10 @@ const RecycleBinItem: React.FC<RecycleBinItemProps> = ({ photo, onRestore, onPer
   const [imageError, setImageError] = useState(false);
 
   const handlePermanentDelete = () => {
-    Alert.alert(
-      'Permanently Delete',
-      'This photo will be permanently deleted and cannot be recovered. Are you sure?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Delete', style: 'destructive', onPress: onPermanentDelete },
-      ]
-    );
+    Alert.alert('Permanently Delete', 'Remove this photo forever?', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: onPermanentDelete },
+    ]);
   };
 
   return (
@@ -136,29 +132,22 @@ export default function RecycleBin() {
   const handleClearAll = () => {
     if (deletedPhotos.length === 0) return;
 
-    Alert.alert(
-      'Clear Recycle Bin',
-      `This will permanently delete all ${deletedPhotos.length} photos and cannot be undone. Are you sure?`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Clear All',
-          style: 'destructive',
-          onPress: async () => {
-            const photosCount = deletedPhotos.length;
-            const success = await clearRecycleBin();
-            if (success) {
-              Alert.alert(
-                'Recycle Bin Cleared',
-                `All photos have been permanently deleted.\n\n⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`
-              );
-            } else {
-              Alert.alert('Error', 'Failed to clear recycle bin.');
-            }
-          },
+    Alert.alert('Clear Recycle Bin', `Delete all ${deletedPhotos.length} photos forever?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Clear All',
+        style: 'destructive',
+        onPress: async () => {
+          const photosCount = deletedPhotos.length;
+          const success = await clearRecycleBin();
+          if (success) {
+            Alert.alert('Recycle Bin Cleared', `Gone! ⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`);
+          } else {
+            Alert.alert('Error', 'Failed to clear recycle bin.');
+          }
         },
-      ]
-    );
+      },
+    ]);
   };
 
   return (
@@ -183,10 +172,10 @@ export default function RecycleBin() {
             <View className="mb-8 items-center">
               <Text className="mb-4 text-6xl">🗑️</Text>
               <Text variant="title2" className="mb-2">
-                Recycle Bin is Empty
+                No Deleted Photos
               </Text>
               <Text color="secondary" className="text-center">
-                Photos you delete will appear here. You can restore them or permanently delete them.
+                Deleted shots show up here. Restore or wipe them.
               </Text>
             </View>
 
@@ -195,13 +184,12 @@ export default function RecycleBin() {
                 💡 Tip
               </Text>
               <Text variant="caption1" className="text-blue-600 dark:text-blue-400">
-                Deleted photos are temporarily stored here for 30 days before being automatically
-                removed.
+                Items stay for 30 days then vanish.
               </Text>
             </View>
             <View className="mt-6">
               <Text variant="caption2" color="secondary" className="text-center">
-                {totalDeleted} photos deleted overall
+                Total deleted: {totalDeleted}
               </Text>
             </View>
           </View>
@@ -241,10 +229,10 @@ export default function RecycleBin() {
             {/* Bottom Info */}
             <View className="border-t border-border bg-gray-50 px-4 py-3 dark:bg-gray-900">
               <Text variant="caption2" color="secondary" className="text-center">
-                Photos will be automatically deleted after 30 days
+                Auto deletion after 30 days
               </Text>
               <Text variant="caption2" color="secondary" className="mt-1 text-center">
-                {totalDeleted} photos deleted overall
+                Total deleted: {totalDeleted}
               </Text>
             </View>
           </View>

--- a/components/BackgroundOptimizer.tsx
+++ b/components/BackgroundOptimizer.tsx
@@ -22,15 +22,21 @@ export const BackgroundOptimizer: React.FC = () => {
   }));
 
   return (
-    <View className="mt-4 items-center justify-center opacity-80">
-      <View className="flex-row items-center">
-        <Ionicons name="hardware-chip" size={px(18)} color="rgb(var(--android-muted-foreground))" />
-        <Text className="ml-2 font-arcade text-xs" color="secondary">
-          Optimizing
-        </Text>
-      </View>
-      <View className="mt-1 h-1 w-20 overflow-hidden rounded-full bg-muted/20">
-        <Animated.View style={[style]} className="h-full bg-primary" />
+    <View className="mt-4 items-center justify-center opacity-90">
+      <View className="tile px-3 py-2">
+        <View className="flex-row items-center">
+          <Ionicons
+            name="hardware-chip"
+            size={px(18)}
+            color="rgb(var(--android-card-foreground))"
+          />
+          <Text className="ml-2 font-arcade text-xs" color="secondary">
+            Optimizing
+          </Text>
+        </View>
+        <View className="mt-1 h-1 w-24 overflow-hidden rounded-full bg-white/20 dark:bg-white/30">
+          <Animated.View style={[style]} className="h-full bg-white" />
+        </View>
       </View>
     </View>
   );

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -271,46 +271,42 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
 
   const resetGallery = async () => {
     // First, confirm the action with the user
-    Alert.alert(
-      'Reset Gallery',
-      'This will reset your gallery progress, clear all deleted photos, and reset your XP to 0. Are you sure?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Reset',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              // Reset the RecycleBin store (clears deletedPhotos and resets XP)
-              await resetRecycleBinStore();
+    Alert.alert('Reset Gallery', 'Reset progress and XP? This also clears deleted photos.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Reset',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            // Reset the RecycleBin store (clears deletedPhotos and resets XP)
+            await resetRecycleBinStore();
 
-              // Reset local component state
-              setKeptPhotos([]);
-              setConfettiKey(0);
-              setPhotos([]);
-              setCurrentPhotoIndex(0);
-              setSessionStartXp(0);
-              setSessionDeletedStart(0);
-              nextCursorRef.current = undefined;
-              prefetchCursorRef.current = undefined;
-              setPrefetchedPhotos([]);
-              setHasMore(true);
+            // Reset local component state
+            setKeptPhotos([]);
+            setConfettiKey(0);
+            setPhotos([]);
+            setCurrentPhotoIndex(0);
+            setSessionStartXp(0);
+            setSessionDeletedStart(0);
+            nextCursorRef.current = undefined;
+            prefetchCursorRef.current = undefined;
+            setPrefetchedPhotos([]);
+            setHasMore(true);
 
-              // Reload photos from the start and wait until done
-              const loaded = await loadPhotos(undefined);
+            // Reload photos from the start and wait until done
+            const loaded = await loadPhotos(undefined);
 
-              if (loaded) {
-                // Notify the user only if photos reloaded successfully
-                Alert.alert('Gallery Reset', 'Your gallery has been reset successfully.');
-              }
-            } catch (error) {
-              console.error('Failed to reset gallery:', error);
-              Alert.alert('Error', 'Failed to reset gallery. Please try again.');
+            if (loaded) {
+              // Notify the user only if photos reloaded successfully
+              Alert.alert('Gallery Reset', 'All set!');
             }
-          },
+          } catch (error) {
+            console.error('Failed to reset gallery:', error);
+            Alert.alert('Error', 'Failed to reset gallery. Please try again.');
+          }
         },
-      ]
-    );
+      },
+    ]);
   };
 
   if (loading) {
@@ -328,10 +324,10 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     return (
       <View className={cn('flex-1 items-center justify-center px-8', className)}>
         <Text variant="title3" className="mb-4 text-center">
-          No Photos Found
+          No Photos
         </Text>
         <Text color="secondary" className="mb-6 text-center">
-          Make sure you have photos in your gallery and have granted permission.
+          Check gallery & permissions.
         </Text>
         <Button onPress={() => loadPhotos()}>
           <Text>Try Again</Text>

--- a/global.css
+++ b/global.css
@@ -93,3 +93,9 @@
     }
   }
 }
+
+@layer components {
+  .tile {
+    @apply rounded-md bg-[rgb(var(--android-card))] shadow-md;
+  }
+}


### PR DESCRIPTION
## Summary
- tune text in PhotoGallery and Recycle Bin for a cleaner look
- style the background optimizer like a 2048 tile
- add a reusable `.tile` style in global CSS

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685fa1aa3020832b9d26dca1f61a0ef5