### PR TITLE
Refine UI with minimal retro tiles

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { PhotoGallery } from '~/components/PhotoGallery';
 export default function Home() {
   return (
     <>
-      <Stack.Screen options={{ title: 'Declutter Photos' }} />
+      <Stack.Screen options={{ headerShown: false }} />
       <Container>
         <PhotoGallery />
       </Container>

--- a/components/BackgroundOptimizer.tsx
+++ b/components/BackgroundOptimizer.tsx
@@ -8,6 +8,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 import { Text } from '~/components/nativewindui/Text';
+import { GameTile } from './GameTile';
 import { px } from '~/lib/pixelPerfect';
 
 export const BackgroundOptimizer: React.FC = () => {
@@ -23,21 +24,21 @@ export const BackgroundOptimizer: React.FC = () => {
 
   return (
     <View className="mt-4 items-center justify-center opacity-90">
-      <View className="tile px-3 py-2">
+      <GameTile className="px-4 py-3">
         <View className="flex-row items-center">
           <Ionicons
             name="hardware-chip"
-            size={px(18)}
+            size={px(20)}
             color="rgb(var(--android-card-foreground))"
           />
           <Text className="ml-2 font-arcade text-xs" color="secondary">
-            Optimizing
+            OPTIMIZING…
           </Text>
         </View>
-        <View className="mt-1 h-1 w-24 overflow-hidden rounded-full bg-white/20 dark:bg-white/30">
+        <View className="mt-2 h-2 w-28 overflow-hidden rounded-full bg-white/20 dark:bg-white/30">
           <Animated.View style={[style]} className="h-full bg-white" />
         </View>
-      </View>
+      </GameTile>
     </View>
   );
 };

--- a/components/GameTile.tsx
+++ b/components/GameTile.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View } from 'react-native';
+import { cn } from '~/lib/cn';
+
+interface GameTileProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const GameTile: React.FC<GameTileProps> = ({ className, children }) => {
+  return <View className={cn('tile items-center justify-center', className)}>{children}</View>;
+};

--- a/components/LevelHeader.tsx
+++ b/components/LevelHeader.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { Text } from '~/components/nativewindui/Text';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
+import { GameTile } from './GameTile';
 import { useRecycleBinStore } from '~/store/store';
 import { cn } from '~/lib/cn';
 
@@ -31,17 +32,11 @@ export const LevelHeader: React.FC<LevelHeaderProps> = ({ className }) => {
   }));
 
   return (
-    <Animated.View
-      style={animatedStyle}
-      className={cn(
-        'items-center rounded-2xl bg-[rgb(var(--android-card))] px-4 py-2 shadow-md dark:bg-[rgb(var(--android-card))]',
-        className
-      )}>
-      <Text className="font-arcade text-lg text-[rgb(var(--android-primary))]">Lv {level}</Text>
-      <ProgressIndicator
-        value={progress}
-        className="mt-1 h-1 w-16 bg-[rgb(var(--android-primary))]"
-      />
+    <Animated.View style={animatedStyle}>
+      <GameTile className={cn('px-4 py-3', className)}>
+        <Text className="font-arcade text-lg text-[rgb(var(--android-primary))]">Lv {level}</Text>
+        <ProgressIndicator value={progress} className="mt-1 h-2 w-20 bg-[rgb(var(--android-primary))]" />
+      </GameTile>
     </Animated.View>
   );
 };

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -11,6 +11,7 @@ import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
+import { Ionicons } from '@expo/vector-icons';
 import { cn } from '~/lib/cn';
 import { px } from '~/lib/pixelPerfect';
 import { useRecycleBinStore, DeletedPhoto, XP_CONFIG } from '~/store/store';
@@ -368,8 +369,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
 
       {/* Reset Button */}
       <View className="mt-6">
-        <Button variant="primary" onPress={resetGallery} className="bg-red-500">
-          <Text className="font-arcade text-sm text-white">Reset</Text>
+        <Button variant="primary" size="icon" onPress={resetGallery} className="bg-red-500">
+          <Ionicons name="refresh" size={px(18)} color="white" />
+          <Text className="sr-only">Reset</Text>
         </Button>
       </View>
       <BackgroundOptimizer />


### PR DESCRIPTION
## Summary
- create reusable `GameTile` component for retro tile styling
- style level header and optimizer using the new tile
- show a refresh icon for reset button
- hide default title on the main screen

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa4103474832bb6fc8103ccacb417