### PR TITLE
Refine retro UI

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,11 +1,8 @@
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { View, Text } from 'react-native';
-import { useEffect, useRef } from 'react';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useRecycleBinStore } from '~/store/store';
-import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
-import { successNotification } from '~/lib/haptics';
+import { ScoreHeader } from '~/components/ScoreHeader';
 
 function RecycleBinTabIcon({ color, size }: { color: string; size: number }) {
   const { deletedPhotos } = useRecycleBinStore();
@@ -24,51 +21,13 @@ function RecycleBinTabIcon({ color, size }: { color: string; size: number }) {
   );
 }
 
-function XPDisplay() {
-  const { xp } = useRecycleBinStore();
-  const scale = useSharedValue(1);
-  const rotate = useSharedValue(0);
-  const prevLevel = useRef(Math.floor(xp / 100) + 1);
-
-  const level = Math.floor(xp / 100) + 1;
-  const progress = xp % 100;
-
-  // Animate XP display only when leveling up
-  useEffect(() => {
-    const leveledUp = level > prevLevel.current;
-    if (leveledUp) {
-      scale.value = 1.8;
-      rotate.value = 15;
-      scale.value = withTiming(1, { duration: 300 });
-      rotate.value = withTiming(0, { duration: 300 });
-      successNotification();
-    }
-    prevLevel.current = level;
-  }, [xp, level, scale, rotate]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }, { rotate: `${rotate.value}deg` }],
-  }));
-
-  return (
-    <Animated.View
-      style={animatedStyle}
-      className="items-center rounded-full bg-[rgb(var(--android-xp)/0.2)] px-3 py-1 dark:bg-[rgb(var(--android-xp)/0.3)]">
-      <Text className="font-arcade text-xs text-[rgb(var(--android-xp))]">
-        ⭐ Lv {level} • {xp} XP
-      </Text>
-      <ProgressIndicator value={progress} className="mt-1 bg-[rgb(var(--android-xp))]" />
-    </Animated.View>
-  );
-}
-
 export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
         headerShown: true,
         headerTitle: '',
-        headerRight: () => <XPDisplay />,
+        headerRight: () => <ScoreHeader />,
         tabBarShowLabel: false,
         tabBarActiveTintColor: '#007AFF',
         tabBarInactiveTintColor: '#8E8E93',

--- a/components/LevelHeader.tsx
+++ b/components/LevelHeader.tsx
@@ -33,9 +33,12 @@ export const LevelHeader: React.FC<LevelHeaderProps> = ({ className }) => {
 
   return (
     <Animated.View style={animatedStyle}>
-      <GameTile className={cn('px-4 py-3', className)}>
-        <Text className="font-arcade text-lg text-[rgb(var(--android-primary))]">Lv {level}</Text>
-        <ProgressIndicator value={progress} className="mt-1 h-2 w-20 bg-[rgb(var(--android-primary))]" />
+      <GameTile className={cn('px-5 py-3', className)}>
+        <Text className="font-arcade text-xl text-[rgb(var(--android-primary))]">Lv {level}</Text>
+        <ProgressIndicator
+          value={progress}
+          className="mt-1 h-2 w-24 bg-[rgb(var(--android-primary))]"
+        />
       </GameTile>
     </Animated.View>
   );

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -315,7 +315,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       <View className={cn('flex-1 items-center justify-center', className)}>
         <ActivityIndicator size="large" />
         <Text className="mt-4" color="secondary">
-          Loading your photos...
+          Loading…
         </Text>
       </View>
     );
@@ -328,7 +328,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
           No Photos
         </Text>
         <Text color="secondary" className="mb-6 text-center">
-          Check gallery & permissions.
+          Check gallery access.
         </Text>
         <Button onPress={() => loadPhotos()}>
           <Text>Try Again</Text>

--- a/components/ScoreHeader.tsx
+++ b/components/ScoreHeader.tsx
@@ -1,0 +1,39 @@
+import React, { useRef, useEffect } from 'react';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+import { GameTile } from './GameTile';
+import { useRecycleBinStore } from '~/store/store';
+import { px } from '~/lib/pixelPerfect';
+import { successNotification } from '~/lib/haptics';
+
+export const ScoreHeader: React.FC = () => {
+  const { xp } = useRecycleBinStore();
+  const scale = useSharedValue(1);
+  const prevLevel = useRef(Math.floor(xp / 100) + 1);
+
+  const level = Math.floor(xp / 100) + 1;
+
+  useEffect(() => {
+    if (level > prevLevel.current) {
+      scale.value = 1.2;
+      scale.value = withTiming(1, { duration: 300 });
+      successNotification();
+    }
+    prevLevel.current = level;
+  }, [level, xp, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View style={[{ flexDirection: 'row', gap: px(6) }, animatedStyle]}>
+      <GameTile className="min-w-[60px] items-center px-2 py-1">
+        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">Lv {level}</Text>
+      </GameTile>
+      <GameTile className="min-w-[60px] items-center px-2 py-1">
+        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">{xp} XP</Text>
+      </GameTile>
+    </Animated.View>
+  );
+};


### PR DESCRIPTION
## Summary
- add `ScoreHeader` for a minimalist level/XP display
- use `ScoreHeader` in tab layout
- enlarge font size in `LevelHeader`
- trim text in `PhotoGallery`

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685fa9f629f0832bbaeba0c0efb95853