### PR TITLE
Refine UI with retro console feel

### DIFF
--- a/components/BackgroundOptimizer.tsx
+++ b/components/BackgroundOptimizer.tsx
@@ -7,7 +7,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
-import { Text } from '~/components/nativewindui/Text';
 import { GameTile } from './GameTile';
 import { px } from '~/lib/pixelPerfect';
 
@@ -24,16 +23,13 @@ export const BackgroundOptimizer: React.FC = () => {
 
   return (
     <View className="mt-4 items-center justify-center opacity-90">
-      <GameTile className="px-4 py-3">
-        <View className="flex-row items-center">
+      <GameTile className="px-4 py-3" accessibilityLabel="Optimizing">
+        <View className="flex-row items-center justify-center">
           <Ionicons
             name="hardware-chip"
             size={px(20)}
             color="rgb(var(--android-card-foreground))"
           />
-          <Text className="ml-2 font-arcade text-xs" color="secondary">
-            OPTIMIZING…
-          </Text>
         </View>
         <View className="mt-2 h-2 w-28 overflow-hidden rounded-full bg-white/20 dark:bg-white/30">
           <Animated.View style={[style]} className="h-full bg-white" />

--- a/components/GameTile.tsx
+++ b/components/GameTile.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, ViewProps } from 'react-native';
 import { cn } from '~/lib/cn';
 
-interface GameTileProps {
+interface GameTileProps extends ViewProps {
   className?: string;
   children?: React.ReactNode;
 }
 
-export const GameTile: React.FC<GameTileProps> = ({ className, children }) => {
-  return <View className={cn('tile items-center justify-center', className)}>{children}</View>;
+export const GameTile: React.FC<GameTileProps> = ({ className, children, ...props }) => {
+  return (
+    <View className={cn('tile items-center justify-center', className)} {...props}>
+      {children}
+    </View>
+  );
 };

--- a/components/ScoreHeader.tsx
+++ b/components/ScoreHeader.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { Text } from '~/components/nativewindui/Text';
 import { GameTile } from './GameTile';
+import { Ionicons } from '@expo/vector-icons';
 import { useRecycleBinStore } from '~/store/store';
 import { px } from '~/lib/pixelPerfect';
 import { successNotification } from '~/lib/haptics';
@@ -27,12 +28,14 @@ export const ScoreHeader: React.FC = () => {
   }));
 
   return (
-    <Animated.View style={[{ flexDirection: 'row', gap: px(6) }, animatedStyle]}>
+    <Animated.View
+      style={[{ flexDirection: 'row', gap: px(6), alignItems: 'center' }, animatedStyle]}>
       <GameTile className="min-w-[60px] items-center px-2 py-1">
         <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">Lv {level}</Text>
       </GameTile>
-      <GameTile className="min-w-[60px] items-center px-2 py-1">
-        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">{xp} XP</Text>
+      <GameTile className="min-w-[60px] flex-row items-center justify-center gap-1 px-2 py-1">
+        <Ionicons name="star" size={px(14)} color="rgb(var(--android-primary))" />
+        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">{xp}</Text>
       </GameTile>
     </Animated.View>
   );


### PR DESCRIPTION
## Summary
- accept extra props in `GameTile`
- slim down `BackgroundOptimizer` so only the chip icon and progress bar show
- swap XP label for star icon in `ScoreHeader`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fabf63cb0832b858d06202d8d4332