### PR TITLE
Improve retro-inspired UI

### DIFF
--- a/app/(tabs)/recycle-bin.tsx
+++ b/app/(tabs)/recycle-bin.tsx
@@ -172,24 +172,10 @@ export default function RecycleBin() {
             <View className="mb-8 items-center">
               <Text className="mb-4 text-6xl">🗑️</Text>
               <Text variant="title2" className="mb-2">
-                No Deleted Photos
+                All Clear
               </Text>
               <Text color="secondary" className="text-center">
-                Deleted shots show up here. Restore or wipe them.
-              </Text>
-            </View>
-
-            <View className="rounded-xl border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950">
-              <Text variant="subhead" className="mb-2 text-blue-700 dark:text-blue-300">
-                💡 Tip
-              </Text>
-              <Text variant="caption1" className="text-blue-600 dark:text-blue-400">
-                Items stay for 30 days then vanish.
-              </Text>
-            </View>
-            <View className="mt-6">
-              <Text variant="caption2" color="secondary" className="text-center">
-                Total deleted: {totalDeleted}
+                Nothing in the bin
               </Text>
             </View>
           </View>
@@ -226,15 +212,6 @@ export default function RecycleBin() {
               </View>
             </ScrollView>
 
-            {/* Bottom Info */}
-            <View className="border-t border-border bg-gray-50 px-4 py-3 dark:bg-gray-900">
-              <Text variant="caption2" color="secondary" className="text-center">
-                Auto deletion after 30 days
-              </Text>
-              <Text variant="caption2" color="secondary" className="mt-1 text-center">
-                Total deleted: {totalDeleted}
-              </Text>
-            </View>
           </View>
         )}
       </Container>

--- a/components/BackgroundOptimizer.tsx
+++ b/components/BackgroundOptimizer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View } from 'react-native';
+import { Text } from '~/components/nativewindui/Text';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -31,6 +32,9 @@ export const BackgroundOptimizer: React.FC = () => {
             color="rgb(var(--android-card-foreground))"
           />
         </View>
+        <Text className="mt-1 font-arcade text-xs text-[rgb(var(--android-card-foreground))]">
+          OPTIMIZING
+        </Text>
         <View className="mt-2 h-2 w-28 overflow-hidden rounded-full bg-white/20 dark:bg-white/30">
           <Animated.View style={[style]} className="h-full bg-white" />
         </View>

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -236,24 +236,19 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
         const msg = pickSessionMessage();
         Alert.alert(
           msg,
-          `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`
+          `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`
         );
       } else {
         loadPhotos().then(() => {
           const msg = pickSessionMessage();
-          Alert.alert(
-            msg,
-            `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`
-          );
+          Alert.alert(msg, `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`);
         });
       }
     } else {
       const endMsg = pickEndMessage();
-      Alert.alert(
-        endMsg,
-        `Deleted: ${deletedThisSession} (this session)\nKept: ${keptPhotos.length}\nTotal Deleted: ${totalDeletedCount}\n\n⭐ Current XP: ${xp}\n🎉 XP earned this session: +${totalXpEarned}`,
-        [{ text: 'OK', style: 'default' }]
-      );
+      Alert.alert(endMsg, `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`, [
+        { text: 'OK', style: 'default' },
+      ]);
     }
   };
 

--- a/components/ScoreHeader.tsx
+++ b/components/ScoreHeader.tsx
@@ -31,11 +31,11 @@ export const ScoreHeader: React.FC = () => {
     <Animated.View
       style={[{ flexDirection: 'row', gap: px(6), alignItems: 'center' }, animatedStyle]}>
       <GameTile className="min-w-[60px] items-center px-2 py-1">
-        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">Lv {level}</Text>
+        <Text className="font-arcade text-base text-[rgb(var(--android-primary))]">{level}</Text>
       </GameTile>
       <GameTile className="min-w-[60px] flex-row items-center justify-center gap-1 px-2 py-1">
         <Ionicons name="star" size={px(14)} color="rgb(var(--android-primary))" />
-        <Text className="font-arcade text-sm text-[rgb(var(--android-primary))]">{xp}</Text>
+        <Text className="font-arcade text-base text-[rgb(var(--android-primary))]">{xp}</Text>
       </GameTile>
     </Animated.View>
   );


### PR DESCRIPTION
## Summary
- streamline recycle bin empty state
- show clear level and XP tiles
- add optimization label in progress widget
- shorten deck summary alerts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb17af728832ba7b643b0f8511d4a