### PR TITLE
Ensure 'Press Start 2P' font is used

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -133,13 +133,14 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: px(28),
-    fontWeight: 'bold',
+    fontFamily: 'Press Start 2P',
     marginBottom: px(10),
     color: '#1A202C',
   },
   subtitle: {
     fontSize: px(18),
     lineHeight: px(26),
+    fontFamily: 'Press Start 2P',
     color: '#4A5568',
     paddingHorizontal: px(20),
     textAlign: 'center',
@@ -157,7 +158,7 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: px(16),
-    fontWeight: '600',
+    fontFamily: 'Press Start 2P',
   },
   skipButtonContainer: {
     backgroundColor: '#E2E8F0',
@@ -165,6 +166,7 @@ const styles = StyleSheet.create({
   },
   skipButtonText: {
     fontSize: px(16),
+    fontFamily: 'Press Start 2P',
     color: '#4A5568',
   },
 });

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+import { Text } from '~/components/nativewindui/Text';
 import { px } from '~/lib/pixelPerfect';
 
 type ButtonProps = {
@@ -36,7 +37,8 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#FFFFFF',
     fontSize: 16,
-    fontWeight: '600',
+    // Use the arcade font
+    fontFamily: 'Press Start 2P',
     textAlign: 'center',
   },
 });

--- a/components/nativewindui/Text.tsx
+++ b/components/nativewindui/Text.tsx
@@ -50,8 +50,8 @@ const fontSizes = {
   caption2: px(11),
 } as const;
 
-// Use a pixel style font by default for a retro look
-const TextClassContext = React.createContext<string | undefined>('font-celeste');
+// Default to the arcade font so all text uses "Press Start 2P"
+const TextClassContext = React.createContext<string | undefined>('font-arcade');
 
 function Text({
   className,


### PR DESCRIPTION
## Summary
- default text font uses "Press Start 2P"
- buttons render text with the arcade font
- onboarding styles now reference "Press Start 2P" directly

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fc133aad8832ba8edf2dff696c45b