### PR TITLE
Fix Press Start 2P font

### DIFF
--- a/GAME_CUSTOMIZATION.md
+++ b/GAME_CUSTOMIZATION.md
@@ -33,12 +33,12 @@ easily reference them in your components.
 ### Tailwind configuration
 
 - **`tailwind.config.js`** maps a `fontFamily` entry called `arcade` to
-  `"Press Start 2P"` so you can apply it with the class `font-arcade`:
+  `"PressStart2P_400Regular"` so you can apply it with the class `font-arcade`:
 
   ```js
   fontFamily: {
     sans: ['Inter', 'System', 'sans-serif'],
-    arcade: ['"Press Start 2P"', 'Inter', 'System', 'sans-serif'],
+    arcade: ['"PressStart2P_400Regular"', 'Inter', 'System', 'sans-serif'],
     celeste: ['"VT323"', 'monospace'],
     funky: ['"Bungee"', 'sans-serif'],
     medieval: ['"UnifrakturCook"', 'serif'],

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ give instant feedback as soon as you start swiping so the game feels snappy and 
    ```bash
    npm install && npx patch-package
    ```
-2. The Inter font and a retro "Press Start 2P" font are bundled and load automatically on startup. See the **Fonts and Typography** section in `GAME_CUSTOMIZATION.md` for a code snippet showing how these fonts are loaded and how to swap them for alternatives.
+2. The Inter font and a retro "Press Start 2P" font are bundled and load automatically on startup. The font is registered under the Expo name `PressStart2P_400Regular`. See the **Fonts and Typography** section in `GAME_CUSTOMIZATION.md` for a code snippet showing how these fonts are loaded and how to swap them for alternatives.
 3. Add sound effects by following the instructions in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 4. (Optional) Place a music file at `assets/music/background.mp3` to enable looping background music. The app starts this track automatically.
 5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep.

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -133,14 +133,15 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: px(28),
-    fontFamily: 'Press Start 2P',
+    // Use Expo's font name for Press Start 2P
+    fontFamily: 'PressStart2P_400Regular',
     marginBottom: px(10),
     color: '#1A202C',
   },
   subtitle: {
     fontSize: px(18),
     lineHeight: px(26),
-    fontFamily: 'Press Start 2P',
+    fontFamily: 'PressStart2P_400Regular',
     color: '#4A5568',
     paddingHorizontal: px(20),
     textAlign: 'center',
@@ -158,7 +159,7 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: px(16),
-    fontFamily: 'Press Start 2P',
+    fontFamily: 'PressStart2P_400Regular',
   },
   skipButtonContainer: {
     backgroundColor: '#E2E8F0',
@@ -166,7 +167,7 @@ const styles = StyleSheet.create({
   },
   skipButtonText: {
     fontSize: px(16),
-    fontFamily: 'Press Start 2P',
+    fontFamily: 'PressStart2P_400Regular',
     color: '#4A5568',
   },
 });

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 16,
     // Use the arcade font
-    fontFamily: 'Press Start 2P',
+    fontFamily: 'PressStart2P_400Regular',
     textAlign: 'center',
   },
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,13 +8,14 @@ module.exports = {
   presets: [require('nativewind/preset')],
   theme: {
     extend: {
-      fontFamily: {
-  sans: ['Inter', 'System', 'sans-serif'],
-  arcade: ['"Press Start 2P"', 'Inter', 'System', 'sans-serif'],
-  celeste: ['"VT323"', 'monospace'],
-  funky: ['"Bungee"', 'sans-serif'],
-  medieval: ['"UnifrakturCook"', 'serif'],
-},
+  fontFamily: {
+        sans: ['Inter', 'System', 'sans-serif'],
+        // Use the Expo font name for Press Start 2P
+        arcade: ['"PressStart2P_400Regular"', 'Inter', 'System', 'sans-serif'],
+        celeste: ['"VT323"', 'monospace'],
+        funky: ['"Bungee"', 'sans-serif'],
+        medieval: ['"UnifrakturCook"', 'serif'],
+      },
       colors: {
         border: withOpacity('border'),
         input: withOpacity('input'),


### PR DESCRIPTION
## Summary
- ensure the arcade font uses the Expo name `PressStart2P_400Regular`
- use this font name in onboarding and button components
- document the Expo font name in the customization guide and README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fc40c774c832b917944956e61d3c4