### PR TITLE
Tune delays for faster interactions

### DIFF
--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -15,8 +15,9 @@ const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
 // Delay before the next card becomes interactive
-const ADVANCE_DELAY = 40;
-const STACK_DELAY = 40; // Faster stack animation for snappier feel
+// Reduced delays for a snappier feel
+const ADVANCE_DELAY = 20;
+const STACK_DELAY = 20;
 
 export interface SwipeDeckItem {
   id: string;

--- a/lib/audioService.ts
+++ b/lib/audioService.ts
@@ -134,7 +134,8 @@ export class AudioService {
     } catch (error) {
       console.warn('Audio playback failed:', error);
     }
-    setTimeout(() => this.processQueue(), 150);
+    // Shorter delay so queued sounds play sooner
+    setTimeout(() => this.processQueue(), 80);
   }
 
   /**


### PR DESCRIPTION
## Summary
- shorten swipe deck block time so cards advance faster
- reduce audio queue delay so consecutive sounds play quickly

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fd6eac0d0832b805e2ab654586a3b