### PR TITLE
Reduce audio queue delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ the `patch-package` script can apply fixes to expo-audio.
 
 ## Swipe Cooldown and Test Mode
 
-A brief 0.15&nbsp;second input mask now blocks touches after each swipe so fast gestures register cleanly while the next card loads.
+Each swipe briefly blocks input for about 20&nbsp;milliseconds while the next card loads. You can tweak this delay by editing `ADVANCE_DELAY` in `components/SwipeDeck.tsx`.
 Tap anywhere five times quickly to simulate a left swipe for debugging.
 
 ### Audio Fallback
 
 Sound playback can fail if audio files are missing or the device blocks audio initialization. When that happens a default chime is used instead. See `lib/audioService.ts` for implementation details.
 
-The audio service queues rapid playback requests so quick swipes never overlap. Each swipe sound waits about 0.15&nbsp;seconds before the next begins. Delete actions sometimes play one of two short voice clips for extra charm.
+The audio service queues rapid playback requests so quick swipes never overlap. By default each sound waits around 40&nbsp;milliseconds before the next begins. Lower the delay in `lib/audioService.ts` if you need even snappier feedback. Delete actions sometimes play one of two short voice clips for extra charm.
 These clips are processed through the same queue so they won't overlap even if you swipe rapidly. To enable the clips, add `voice1.mp3` and `voice2.mp3` under `assets/sounds/` as described in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 
 ## Performance Tips

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -14,8 +14,8 @@ import { px } from '~/lib/pixelPerfect';
 const { width: screenWidth } = Dimensions.get('window');
 const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
-// Delay before the next card becomes interactive
-// Reduced delays for a snappier feel
+// Delay before the next card becomes interactive (ms)
+// Lower values reduce perceived lag after swipes
 const ADVANCE_DELAY = 20;
 const STACK_DELAY = 20;
 

--- a/lib/audioService.ts
+++ b/lib/audioService.ts
@@ -134,8 +134,9 @@ export class AudioService {
     } catch (error) {
       console.warn('Audio playback failed:', error);
     }
-    // Shorter delay so queued sounds play sooner
-    setTimeout(() => this.processQueue(), 80);
+    // Delay before playing the next queued sound
+    // Lower value means snappier audio but may overlap if too small
+    setTimeout(() => this.processQueue(), 40);
   }
 
   /**


### PR DESCRIPTION
## Summary
- trim input mask doc to 20ms and explain how to adjust
- note default 40ms audio delay in audioService
- clarify comments about swipe delay and audio queue

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fd93c8758832b9c255c085cc6a022