### PR TITLE
Reduce swipe and audio delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ the `patch-package` script can apply fixes to expo-audio.
 
 ## Swipe Cooldown and Test Mode
 
-Each swipe briefly blocks input for about 20&nbsp;milliseconds while the next card loads. You can tweak this delay by editing `ADVANCE_DELAY` in `components/SwipeDeck.tsx`.
+Each swipe briefly blocks input for about 10&nbsp;milliseconds while the next card loads. You can tweak this delay by editing `ADVANCE_DELAY` in `components/SwipeDeck.tsx`.
 Tap anywhere five times quickly to simulate a left swipe for debugging.
 
 ### Audio Fallback
 
 Sound playback can fail if audio files are missing or the device blocks audio initialization. When that happens a default chime is used instead. See `lib/audioService.ts` for implementation details.
 
-The audio service queues rapid playback requests so quick swipes never overlap. By default each sound waits around 40&nbsp;milliseconds before the next begins. Lower the delay in `lib/audioService.ts` if you need even snappier feedback. Delete actions sometimes play one of two short voice clips for extra charm.
+The audio service queues rapid playback requests so quick swipes never overlap. By default each sound waits around 25&nbsp;milliseconds before the next begins. Lower the delay in `lib/audioService.ts` if you need even snappier feedback. Delete actions sometimes play one of two short voice clips for extra charm.
 These clips are processed through the same queue so they won't overlap even if you swipe rapidly. To enable the clips, add `voice1.mp3` and `voice2.mp3` under `assets/sounds/` as described in `assets/sounds/SETUP_INSTRUCTIONS.md`.
 
 ## Performance Tips

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -16,8 +16,8 @@ const DECK_WIDTH = px(screenWidth * 0.9);
 const DECK_HEIGHT = px(screenWidth * 1.2);
 // Delay before the next card becomes interactive (ms)
 // Lower values reduce perceived lag after swipes
-const ADVANCE_DELAY = 20;
-const STACK_DELAY = 20;
+const ADVANCE_DELAY = 10;
+const STACK_DELAY = 10;
 
 export interface SwipeDeckItem {
   id: string;

--- a/lib/audioService.ts
+++ b/lib/audioService.ts
@@ -136,7 +136,7 @@ export class AudioService {
     }
     // Delay before playing the next queued sound
     // Lower value means snappier audio but may overlap if too small
-    setTimeout(() => this.processQueue(), 40);
+    setTimeout(() => this.processQueue(), 25);
   }
 
   /**


### PR DESCRIPTION
## Summary
- tweak `SwipeDeck` advance and stack delays to 10ms
- play queued audio sooner with 25ms spacing
- document new default delays

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fdaf0c0c0832b98e26bcd8ed68325