### PR TITLE
Add retro start overlay

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -5,6 +5,7 @@ import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
 import { XPToast } from './XPToast';
 import { LevelHeader } from './LevelHeader';
 import { SwipeHint } from './SwipeHint';
+import { RetroStart } from './RetroStart';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
 import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
@@ -68,6 +69,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
   const [confettiKey, setConfettiKey] = useState(0);
   const [xpToast, setXpToast] = useState<number | null>(null);
   const [showSwipeHint, setShowSwipeHint] = useState(true);
+  const [showStart, setShowStart] = useState(false);
+  const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   // Track total deletes this session for surprise messages
   const deleteCountRef = React.useRef(0);
@@ -78,6 +81,13 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     const timeout = setTimeout(() => setShowSwipeHint(false), 3000);
     return () => clearTimeout(timeout);
   }, []);
+
+  useEffect(() => {
+    if (photos.length > 0 && !startShownRef.current) {
+      setShowStart(true);
+      startShownRef.current = true;
+    }
+  }, [photos.length]);
 
   const loadPhotos = React.useCallback(async (cursor?: string): Promise<boolean> => {
     try {
@@ -293,6 +303,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
             prefetchCursorRef.current = undefined;
             setPrefetchedPhotos([]);
             setHasMore(true);
+            startShownRef.current = false;
+            setShowStart(false);
 
             // Reload photos from the start and wait until done
             const loaded = await loadPhotos(undefined);
@@ -341,6 +353,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     <Pressable
       onPress={handleDebugTap}
       className={cn('flex-1 items-center justify-center', className)}>
+      {showStart && <RetroStart onDone={() => setShowStart(false)} />}
       <LevelHeader className="mb-6" />
 
       {/* Swipe Deck */}

--- a/components/RetroStart.tsx
+++ b/components/RetroStart.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+
+interface RetroStartProps {
+  onDone?: () => void;
+}
+
+export const RetroStart: React.FC<RetroStartProps> = ({ onDone }) => {
+  const [label, setLabel] = useState('READY');
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(0.5);
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration: 200 });
+    scale.value = withTiming(1, { duration: 300 });
+
+    const readyTimeout = setTimeout(() => {
+      setLabel('GO!');
+      scale.value = withTiming(1.2, { duration: 200 });
+      const doneTimeout = setTimeout(() => {
+        opacity.value = withTiming(0, { duration: 300 }, () => {
+          if (onDone) runOnJS(onDone)();
+        });
+      }, 500);
+      return () => clearTimeout(doneTimeout);
+    }, 600);
+
+    return () => clearTimeout(readyTimeout);
+  }, [onDone, opacity, scale]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        {
+          position: 'absolute',
+          top: '40%',
+          left: 0,
+          right: 0,
+          alignItems: 'center',
+        },
+        style,
+      ]}>
+      <Text className="font-arcade text-3xl text-[rgb(var(--android-primary))]">{label}</Text>
+    </Animated.View>
+  );
+};


### PR DESCRIPTION
## Summary
- add RetroStart overlay with quick READY → GO! animation
- trigger overlay when gallery photos load
- reset overlay state when gallery is reset

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff0b6ee20832bbea0445b65fcd31e