### PR TITLE
Add retro overlay and XP toast animation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,7 @@ import { useCustomFonts } from '~/lib/useCustomFonts';
 import { backgroundMusicService } from '~/lib/backgroundMusic';
 import { audioService } from '~/lib/audioService';
 import { NAV_THEME } from '~/theme';
+import RetroOverlay from '~/components/RetroOverlay';
 
 export function ErrorBoundary({ error }: { error: Error }) {
   console.error(error);
@@ -100,6 +101,7 @@ export default function RootLayout() {
       </GestureHandlerRootView>
 
       {/* </ExampleProvider> */}
+      <RetroOverlay />
     </>
   );
 }

--- a/components/RetroOverlay.tsx
+++ b/components/RetroOverlay.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+export const RetroOverlay: React.FC = () => {
+  const offset = useSharedValue(0);
+
+  useEffect(() => {
+    offset.value = withRepeat(withTiming(-4, { duration: 800 }), -1, true);
+  }, [offset]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: offset.value }],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[StyleSheet.absoluteFill, styles.overlay, animatedStyle]}>
+      <LinearGradient
+        colors={['rgba(255,255,255,0.04)', 'rgba(255,255,255,0)', 'rgba(255,255,255,0.04)']}
+        style={StyleSheet.absoluteFill}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+      />
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    zIndex: 100,
+  },
+});
+
+export default RetroOverlay;

--- a/components/XPToast.tsx
+++ b/components/XPToast.tsx
@@ -4,6 +4,7 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
   withSpring,
+  withSequence,
   runOnJS,
 } from 'react-native-reanimated';
 import { Text } from '~/components/nativewindui/Text';
@@ -22,7 +23,10 @@ export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
   useEffect(() => {
     opacity.value = withTiming(1, { duration: 100 });
     translateY.value = withTiming(0, { duration: 100 });
-    scale.value = withSpring(1, { damping: 8, stiffness: 200 });
+    scale.value = withSequence(
+      withTiming(1.2, { duration: 150 }),
+      withSpring(1, { damping: 8, stiffness: 200 })
+    );
 
     const timeout = setTimeout(() => {
       opacity.value = withTiming(0, { duration: 300 }, () => {


### PR DESCRIPTION
## Summary
- add `RetroOverlay` component for a CRT-style overlay
- display the overlay in the root layout
- give XP toast a quick scale animation for smoother appearance

## Testing
- `npm install`
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685ff0b6ee20832bbea0445b65fcd31e