### PR TITLE
Enhance retro feel with level up overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ give instant feedback as soon as you start swiping so the game feels snappy and 
 4. (Optional) Place a music file at `assets/music/background.mp3` to enable looping background music. The app starts this track automatically.
 5. Use fun, game‑inspired sounds: a quick "zap" for delete and a cheerful "coin" for keep.
 6. For a nostalgic feel, pick short 8-bit style clips reminiscent of retro Nintendo games. A confetti burst celebrates each level up.
-7. The `audioService` will load these sounds automatically and handle failures gracefully.
-8. Subtle haptic feedback triggers on each swipe for extra game feel.
-9. A small header widget shows your **level** and XP with a progress bar that fills as you get closer to leveling up.
-10. The file `assets/favicon.png` serves as the favicon when running on the web. Replace it with your own image to customize the icon.
-11. Enable **Zen Mode** from the gallery screen to hide stats and confetti for a stress-free experience.
+7. Level ups display a bold "LEVEL UP!" overlay with a quick retro bounce.
+8. The `audioService` will load these sounds automatically and handle failures gracefully.
+9. Subtle haptic feedback triggers on each swipe for extra game feel.
+10. A small header widget shows your **level** and XP with a progress bar that fills as you get closer to leveling up.
+11. The file `assets/favicon.png` serves as the favicon when running on the web. Replace it with your own image to customize the icon.
+12. Enable **Zen Mode** from the gallery screen to hide stats and confetti for a stress-free experience.
 
 ## Running the App on Android
 

--- a/components/LevelUpOverlay.tsx
+++ b/components/LevelUpOverlay.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSequence,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+
+interface LevelUpOverlayProps {
+  onDone?: () => void;
+}
+
+export const LevelUpOverlay: React.FC<LevelUpOverlayProps> = ({ onDone }) => {
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(0.5);
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration: 150 });
+    scale.value = withSequence(
+      withTiming(1.3, { duration: 250 }),
+      withTiming(1, { duration: 150 })
+    );
+    const timeout = setTimeout(() => {
+      opacity.value = withTiming(0, { duration: 300 }, () => {
+        if (onDone) runOnJS(onDone)();
+      });
+    }, 800);
+    return () => clearTimeout(timeout);
+  }, [onDone, opacity, scale]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, styles.center, style]}>
+      <Text className="font-arcade text-3xl text-[rgb(var(--android-primary))]">LEVEL UP!</Text>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default LevelUpOverlay;

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -4,6 +4,7 @@ import ConfettiCannon from 'react-native-confetti-cannon';
 import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
 import { XPToast } from './XPToast';
 import { LevelHeader } from './LevelHeader';
+import { LevelUpOverlay } from './LevelUpOverlay';
 import { SwipeHint } from './SwipeHint';
 import { RetroStart } from './RetroStart';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
@@ -11,7 +12,6 @@ import { fetchPhotoAssetsWithPagination } from '~/lib/mediaLibrary';
 import { Text } from '~/components/nativewindui/Text';
 import { ActivityIndicator } from '~/components/nativewindui/ActivityIndicator';
 import { Button } from '~/components/nativewindui/Button';
-import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
 import { Ionicons } from '@expo/vector-icons';
 import { cn } from '~/lib/cn';
 import { px } from '~/lib/pixelPerfect';
@@ -70,6 +70,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
   const [xpToast, setXpToast] = useState<number | null>(null);
   const [showSwipeHint, setShowSwipeHint] = useState(true);
   const [showStart, setShowStart] = useState(false);
+  const [showLevelUp, setShowLevelUp] = useState(false);
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   // Track total deletes this session for surprise messages
@@ -179,6 +180,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     // Trigger confetti on level ups or long delete streaks
     if (newLevel > prevLevel || consecutiveDeleteRef.current >= STREAK_THRESHOLD) {
       setConfettiKey((k) => k + 1);
+      if (newLevel > prevLevel) {
+        setShowLevelUp(true);
+      }
       if (consecutiveDeleteRef.current >= STREAK_THRESHOLD) {
         consecutiveDeleteRef.current = 0;
       }
@@ -379,6 +383,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
           origin={{ x: Dimensions.get('window').width / 2, y: 0 }}
         />
       )}
+
+      {showLevelUp && <LevelUpOverlay onDone={() => setShowLevelUp(false)} />}
 
       {/* Reset Button */}
       <View className="mt-6">

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -47,6 +47,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
+  const rotateZ = useSharedValue(0);
   const { playDeleteSound, playKeepSound } = useSwipeAudio();
   const onTap = () => lightImpact();
 
@@ -61,12 +62,14 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       if (!disabled) {
         translateX.value = event.translationX;
         translateY.value = event.translationY * 0.05; // Reduce vertical movement
+        rotateZ.value = event.translationX * 0.001;
       }
     },
     onEnd: (event) => {
       if (disabled) return;
 
       scale.value = withSpring(1);
+      rotateZ.value = withSpring(0);
 
       const velocityX = event.velocityX;
       const shouldSwipeLeft = translateX.value < -SWIPE_THRESHOLD || velocityX < -1000;
@@ -82,6 +85,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
+        rotateZ.value = withTiming(-20, { duration: SWIPE_EXIT_DURATION });
         // Play delete sound and trigger callback
         runOnJS(playDeleteSound)();
         if (onSwipeLeft) {
@@ -97,6 +101,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           duration: SWIPE_EXIT_DURATION,
           easing: Easing.out(Easing.cubic),
         });
+        rotateZ.value = withTiming(20, { duration: SWIPE_EXIT_DURATION });
         // Play keep sound and trigger callback
         runOnJS(playKeepSound)();
         if (onSwipeRight) {
@@ -107,6 +112,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
         const springConfig = { damping: 15, stiffness: 200 };
         translateX.value = withSpring(0, springConfig);
         translateY.value = withSpring(0, springConfig);
+        rotateZ.value = withSpring(0, springConfig);
       }
     },
   });
@@ -118,6 +124,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       transform: [
         { translateX: translateX.value },
         { translateY: translateY.value },
+        { rotateZ: `${rotateZ.value}deg` },
         { scale: scale.value },
       ],
       opacity,


### PR DESCRIPTION
## Summary
- add animated **LevelUpOverlay** for retro level up message
- rotate SwipeCard as you swipe for smoother feel
- trigger the level up overlay when XP increases
- document new overlay feature in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ff3378b6c832ba6f36506c153b51c