### PR TITLE
Fix doc typo in button comment

### DIFF
--- a/codex-enhance.patch
+++ b/codex-enhance.patch
@@ -262,7 +262,7 @@ index 002601f262ff54be496d3601e02aecd2781b792a..8c135d1d70d52599b99357d0b8757587
  
  type AndroidOnlyButtonProps = {
    /**
-    * ANDROID ONLY: The class name of root responsible for hidding the ripple overflow.
+    * ANDROID ONLY: The class name of root responsible for hiding the ripple overflow.
     */
    androidRootClassName?: string;
  };

--- a/components/nativewindui/Button.tsx
+++ b/components/nativewindui/Button.tsx
@@ -110,7 +110,7 @@ type ButtonVariantProps = Omit<VariantProps<typeof buttonVariants>, 'variant'> &
 
 type AndroidOnlyButtonProps = {
   /**
-   * ANDROID ONLY: The class name of root responsible for hidding the ripple overflow.
+   * ANDROID ONLY: The class name of root responsible for hiding the ripple overflow.
    */
   androidRootClassName?: string;
 };


### PR DESCRIPTION
## Summary
- fix spelling of "hiding" in Button prop description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600c5d200c832bb1c3e3d0d5c74a98