### PR TITLE
Pin expo-audio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
     "expo": "^53.0.9",
-    "expo-audio": "~0.4.5",
+    "expo-audio": "0.4.5",
     "expo-constants": "~17.1.4",
     "expo-dev-client": "~5.1.7",
     "expo-dev-launcher": "^5.0.17",


### PR DESCRIPTION
## Summary
- pin `expo-audio` dependency to exact `0.4.5`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68600f0420c8832bb30fb4ec070e2743