### PR TITLE
Add retro pixel burst animation

### DIFF
--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -6,6 +6,7 @@ import { XPToast } from './XPToast';
 import { LevelHeader } from './LevelHeader';
 import { LevelUpOverlay } from './LevelUpOverlay';
 import { SwipeFlash } from './SwipeFlash';
+import { PixelBurst } from './PixelBurst';
 import { SwipeHint } from './SwipeHint';
 import { RetroStart } from './RetroStart';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
@@ -72,6 +73,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
   const [showSwipeHint, setShowSwipeHint] = useState(true);
   const [showStart, setShowStart] = useState(false);
   const [showLevelUp, setShowLevelUp] = useState(false);
+  const [burstColor, setBurstColor] = useState<string | null>(null);
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   // Track total deletes this session for surprise messages
@@ -168,6 +170,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     addDeletedPhoto(deletedPhoto); // XP assignment happens in the store
     setXpToast(XP_CONFIG.DELETE_PHOTO);
     setSwipeFlash('DELETED!');
+    setBurstColor('rgb(255,59,48)');
     setShowSwipeHint(false);
     // Play a random voice clip for extra feedback
     audioService.playRandomVoice();
@@ -207,6 +210,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
     // Swipe event - user keeps the current photo
     setKeptPhotos((prev) => [...prev, item.imageUri]);
     setSwipeFlash('KEPT!');
+    setBurstColor('rgb(52,199,89)');
     setShowSwipeHint(false);
 
     // Reset streak when a photo is kept
@@ -377,6 +381,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
       {xpToast && <XPToast amount={xpToast} onDone={() => setXpToast(null)} />}
 
       {swipeFlash && <SwipeFlash label={swipeFlash} onDone={() => setSwipeFlash(null)} />}
+
+      {burstColor && <PixelBurst color={burstColor} onDone={() => setBurstColor(null)} />}
 
       {/* Confetti burst when deleting */}
       {confettiKey > 0 && (

--- a/components/PixelBurst.tsx
+++ b/components/PixelBurst.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
+import { px } from '~/lib/pixelPerfect';
+
+interface PixelBurstProps {
+  /** Hex color or rgb string for the pixel pieces */
+  color?: string;
+  onDone?: () => void;
+}
+
+export const PixelBurst: React.FC<PixelBurstProps> = ({ color = 'white', onDone }) => {
+  const pieces = Array.from({ length: 8 }).map(() => ({
+    x: useSharedValue(0),
+    y: useSharedValue(0),
+    opacity: useSharedValue(1),
+  }));
+
+  useEffect(() => {
+    pieces.forEach((p) => {
+      const angle = Math.random() * Math.PI * 2;
+      const distance = px(20 + Math.random() * 20);
+      p.x.value = withTiming(Math.cos(angle) * distance, { duration: 300 });
+      p.y.value = withTiming(Math.sin(angle) * distance, { duration: 300 });
+      p.opacity.value = withTiming(0, { duration: 300 });
+    });
+    const timer = setTimeout(() => {
+      if (onDone) onDone();
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [onDone, pieces]);
+
+  return (
+    <View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        marginLeft: -px(2),
+        marginTop: -px(2),
+      }}>
+      {pieces.map((p, i) => {
+        const style = useAnimatedStyle(() => ({
+          transform: [{ translateX: p.x.value }, { translateY: p.y.value }],
+          opacity: p.opacity.value,
+        }));
+        return (
+          <Animated.View
+            key={i}
+            style={[
+              {
+                width: px(4),
+                height: px(4),
+                backgroundColor: color,
+                position: 'absolute',
+              },
+              style,
+            ]}
+          />
+        );
+      })}
+    </View>
+  );
+};
+
+export default PixelBurst;


### PR DESCRIPTION
## Summary
- add `PixelBurst` component for retro swipe effects
- trigger pixel burst on left/right swipe in `PhotoGallery`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686149a49e64832bad8004939d5f63be