### PR TITLE
Minimal retro polish

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { useRecycleBinStore } from '~/store/store';
 import { ScoreHeader } from '~/components/ScoreHeader';
 
@@ -11,11 +11,7 @@ function RecycleBinTabIcon({ color, size }: { color: string; size: number }) {
     <View className="relative">
       <Ionicons name="trash" size={size} color={color} />
       {deletedPhotos.length > 0 && (
-        <View className="absolute -right-1 -top-1 h-4 min-w-4 items-center justify-center rounded-full bg-red-500">
-          <Text className="text-xs font-bold text-white" style={{ fontSize: 10 }}>
-            {deletedPhotos.length > 99 ? '99+' : deletedPhotos.length}
-          </Text>
-        </View>
+        <View className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-red-500" />
       )}
     </View>
   );

--- a/app/(tabs)/recycle-bin.tsx
+++ b/app/(tabs)/recycle-bin.tsx
@@ -104,20 +104,14 @@ export default function RecycleBin() {
   const handleRestore = (photoId: string) => {
     const restoredPhoto = restorePhoto(photoId);
     if (restoredPhoto) {
-      Alert.alert(
-        'Photo Restored',
-        `The photo has been restored successfully.\n\n🔄 -${Math.abs(XP_CONFIG.RESTORE_PHOTO)} XP`
-      );
+      Alert.alert('Photo Restored', 'The photo has been restored.');
     }
   };
 
   const handlePermanentDelete = async (photoId: string) => {
     const success = await permanentlyDelete(photoId);
     if (success) {
-      Alert.alert(
-        'Photo Deleted',
-        `The photo has been permanently deleted.\n\n⭐ +${XP_CONFIG.PERMANENT_DELETE} XP`
-      );
+      Alert.alert('Photo Deleted', 'Removed forever.');
     } else {
       Alert.alert('Error', 'Failed to delete photo. Please try again.');
     }
@@ -126,16 +120,15 @@ export default function RecycleBin() {
   const handleClearAll = () => {
     if (deletedPhotos.length === 0) return;
 
-    Alert.alert('Clear Recycle Bin', `Delete all ${deletedPhotos.length} photos forever?`, [
+    Alert.alert('Clear Recycle Bin', 'Delete all photos forever?', [
       { text: 'Cancel', style: 'cancel' },
       {
         text: 'Clear All',
         style: 'destructive',
         onPress: async () => {
-          const photosCount = deletedPhotos.length;
           const success = await clearRecycleBin();
           if (success) {
-            Alert.alert('Recycle Bin Cleared', `Gone! ⭐ +${XP_CONFIG.CLEAR_ALL * photosCount} XP`);
+            Alert.alert('Recycle Bin Cleared', 'All gone!');
           } else {
             Alert.alert('Error', 'Failed to clear recycle bin.');
           }

--- a/components/LevelHeader.tsx
+++ b/components/LevelHeader.tsx
@@ -2,9 +2,11 @@ import React, { useRef, useEffect } from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { Text } from '~/components/nativewindui/Text';
 import { ProgressIndicator } from '~/components/nativewindui/ProgressIndicator';
+import { Ionicons } from '@expo/vector-icons';
 import { GameTile } from './GameTile';
 import { useRecycleBinStore } from '~/store/store';
 import { cn } from '~/lib/cn';
+import { px } from '~/lib/pixelPerfect';
 
 interface LevelHeaderProps {
   className?: string;
@@ -34,7 +36,10 @@ export const LevelHeader: React.FC<LevelHeaderProps> = ({ className }) => {
   return (
     <Animated.View style={animatedStyle}>
       <GameTile className={cn('px-5 py-3', className)}>
-        <Text className="font-arcade text-xl text-[rgb(var(--android-primary))]">Lv {level}</Text>
+        <Animated.View className="mb-1 flex-row items-center justify-center gap-1">
+          <Text className="font-arcade text-xl text-[rgb(var(--android-primary))]">LEVEL</Text>
+          <Ionicons name="star" size={px(14)} color="rgb(var(--android-primary))" />
+        </Animated.View>
         <ProgressIndicator
           value={progress}
           className="mt-1 h-2 w-24 bg-[rgb(var(--android-primary))]"

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -254,26 +254,16 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
           setHasMore(false);
         }
         const msg = pickSessionMessage();
-        Alert.alert(
-          msg,
-          `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`
-        );
+        Alert.alert(msg, 'Keep it up!');
       } else {
         loadPhotos().then(() => {
           const msg = pickSessionMessage();
-          Alert.alert(
-            msg,
-            `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`
-          );
+          Alert.alert(msg, 'Keep it up!');
         });
       }
     } else {
       const endMsg = pickEndMessage();
-      Alert.alert(
-        endMsg,
-        `⭐ ${xp} (+${totalXpEarned})\n🗑 ${deletedThisSession}  📷 ${keptPhotos.length}`,
-        [{ text: 'OK', style: 'default' }]
-      );
+      Alert.alert(endMsg, 'Gallery clean!', [{ text: 'OK', style: 'default' }]);
     }
   };
 

--- a/components/ScoreHeader.tsx
+++ b/components/ScoreHeader.tsx
@@ -1,8 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import { Text } from '~/components/nativewindui/Text';
-import { GameTile } from './GameTile';
 import { Ionicons } from '@expo/vector-icons';
+import { GameTile } from './GameTile';
 import { useRecycleBinStore } from '~/store/store';
 import { px } from '~/lib/pixelPerfect';
 import { successNotification } from '~/lib/haptics';
@@ -28,14 +27,9 @@ export const ScoreHeader: React.FC = () => {
   }));
 
   return (
-    <Animated.View
-      style={[{ flexDirection: 'row', gap: px(6), alignItems: 'center' }, animatedStyle]}>
-      <GameTile className="min-w-[60px] items-center px-2 py-1">
-        <Text className="font-arcade text-base text-[rgb(var(--android-primary))]">{level}</Text>
-      </GameTile>
-      <GameTile className="min-w-[60px] flex-row items-center justify-center gap-1 px-2 py-1">
-        <Ionicons name="star" size={px(14)} color="rgb(var(--android-primary))" />
-        <Text className="font-arcade text-base text-[rgb(var(--android-primary))]">{xp}</Text>
+    <Animated.View style={[{ alignItems: 'center' }, animatedStyle]}>
+      <GameTile className="min-w-[32px] items-center px-2 py-1">
+        <Ionicons name="star" size={px(16)} color="rgb(var(--android-primary))" />
       </GameTile>
     </Animated.View>
   );

--- a/components/XPToast.tsx
+++ b/components/XPToast.tsx
@@ -59,7 +59,7 @@ export const XPToast: React.FC<XPToastProps> = ({ amount, onDone }) => {
         style,
       ]}
       pointerEvents="none">
-      <Text className="font-arcade text-white">+{amount} XP</Text>
+      <Text className="font-arcade text-white">BONUS!</Text>
     </Animated.View>
   );
 };


### PR DESCRIPTION
## Summary
- simplify LevelHeader to remove numeric level text
- show only a star indicator in ScoreHeader
- replace XP toast text with a bonus message
- streamline recycle bin alerts and badges
- simplify session summaries for a clean retro vibe

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68614bdcb074832b825c61e9928bb655