### PR TITLE
Add subtle gradient background and fade-in effect

### DIFF
--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -1,11 +1,26 @@
 import { StyleSheet, SafeAreaView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useColorScheme } from '~/lib/useColorScheme';
+import { COLORS } from '~/theme/colors';
 import { px } from '~/lib/pixelPerfect';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
-  return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;
+  const { colorScheme } = useColorScheme();
+  const colors =
+    colorScheme === 'dark'
+      ? [COLORS.dark.background, COLORS.dark.grey6]
+      : [COLORS.light.background, COLORS.light.grey5];
+  return (
+    <LinearGradient colors={colors} style={styles.gradient}>
+      <SafeAreaView style={styles.container}>{children}</SafeAreaView>
+    </LinearGradient>
+  );
 };
 
 const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     padding: px(18),

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Image, Dimensions } from 'react-native';
+import { View, Dimensions } from 'react-native';
 import {
   PanGestureHandler,
   PanGestureHandlerGestureEvent,
@@ -15,6 +15,7 @@ import Animated, {
   interpolate,
   runOnJS,
   Easing,
+  FadeIn,
 } from 'react-native-reanimated';
 import { useSwipeAudio } from '~/lib/useSwipeAudio';
 import { lightImpact } from '~/lib/haptics';
@@ -193,7 +194,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
               animatedStyle,
               style,
             ]}>
-        <Image
+        <Animated.Image
+          entering={FadeIn.duration(200)}
           source={{ uri: imageUri }}
           style={{
             width: '100%',


### PR DESCRIPTION
## Summary
- enhance Container with a light/dark gradient
- smooth SwipeCard image appearance with a FadeIn animation
- keep the minimalist aesthetic with subtle visuals

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7f09c31c832b901209cae2aa2e2d