### PR TITLE
Add analysis screen with faster photo categorization

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -35,17 +35,29 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="home" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="analysis"
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="search" size={size} color={color} />
+          ),
         }}
       />
       <Tabs.Screen
         name="recycle-bin"
         options={{
-          tabBarIcon: ({ color, size }) => <RecycleBinTabIcon color={color} size={size} />,
+          tabBarIcon: ({ color, size }) => (
+            <RecycleBinTabIcon color={color} size={size} />
+          ),
         }}
       />
       {/**
-       * Extra tabs removed for a leaner experience. Only Home and Recycle Bin remain.
+       * Extra tabs removed for a leaner experience. Only Home, Scan and Recycle Bin remain.
        */}
     </Tabs>
   );

--- a/app/(tabs)/analysis.tsx
+++ b/app/(tabs)/analysis.tsx
@@ -1,0 +1,56 @@
+import { Stack } from 'expo-router';
+import { useState } from 'react';
+import { View, Alert } from 'react-native';
+import { Button } from '~/components/nativewindui/Button';
+import { Text } from '~/components/nativewindui/Text';
+import { analyzePhotos, PhotoAnalysisResult } from '~/lib/photoAnalyzer';
+
+export default function AnalysisScreen() {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<PhotoAnalysisResult | null>(null);
+
+  const handleScan = async () => {
+    setLoading(true);
+    try {
+      const res = await analyzePhotos();
+      setResult(res);
+    } catch (err) {
+      console.error('Failed to analyze photos', err);
+      Alert.alert('Error', 'Failed to analyze photos.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Scan' }} />
+      <View className="flex-1 items-center justify-center p-4">
+        {result ? (
+          <View className="mb-6 items-center">
+            <Text variant="title3" className="mb-4">
+              Results
+            </Text>
+            <Text className="mb-1">
+              Portrait: {result.byOrientation.portrait.length}
+            </Text>
+            <Text className="mb-1">
+              Landscape: {result.byOrientation.landscape.length}
+            </Text>
+            <Text className="mb-1">
+              Square: {result.byOrientation.square.length}
+            </Text>
+            <Text>Duplicate groups: {result.duplicates.length}</Text>
+          </View>
+        ) : (
+          <Text className="mb-4 text-center">
+            Analyze your gallery to categorize photos and find duplicates.
+          </Text>
+        )}
+        <Button onPress={handleScan} variant="primary" disabled={loading}>
+          <Text>{loading ? 'Scanning…' : 'Start Scan'}</Text>
+        </Button>
+      </View>
+    </>
+  );
+}

--- a/lib/photoAnalyzer.ts
+++ b/lib/photoAnalyzer.ts
@@ -20,9 +20,14 @@ export async function analyzePhotos(): Promise<PhotoAnalysisResult> {
   };
   const dupMap: Record<string, PhotoAsset[]> = {};
 
-  for (const asset of assets) {
-    const info = await getAssetInfo(asset.id);
-    if (!info) continue;
+  // Fetch detailed info for all assets concurrently for faster scanning
+  const infos = await Promise.all(
+    assets.map((asset) => getAssetInfo(asset.id))
+  );
+
+  infos.forEach((info, idx) => {
+    if (!info) return;
+    const asset = assets[idx];
     const orientation: Orientation =
       info.width > info.height
         ? 'landscape'
@@ -36,7 +41,7 @@ export async function analyzePhotos(): Promise<PhotoAnalysisResult> {
       dupMap[key] = [];
     }
     dupMap[key].push(asset);
-  }
+  });
 
   const duplicates: PhotoAsset[][] = [];
   Object.values(dupMap).forEach((group) => {


### PR DESCRIPTION
## Summary
- improve `analyzePhotos` to fetch info concurrently for faster scanning
- add new `analysis` screen that categorizes photos and lists duplicates
- expose new screen in the tab layout

## Testing
- `npm install`
- `npm test`
- `npm run lint` *(fails: React Hooks usage errors, parsing errors)*
- `npm run format` *(fails: same parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6b27ec4832b972391b9e8af3b3e