### PR TITLE
Implement basic photo categorization

### DIFF
--- a/__tests__/photoAnalyzer.test.ts
+++ b/__tests__/photoAnalyzer.test.ts
@@ -16,24 +16,45 @@ describe('photoAnalyzer', () => {
       { id: '1', uri: 'u1' },
       { id: '2', uri: 'u2' },
       { id: '3', uri: 'u3' },
+      { id: '4', uri: 'u4' },
     ]);
     (media.getAssetInfo as jest.Mock).mockImplementation((id: string) => {
       switch (id) {
         case '1':
-          return Promise.resolve({ id: '1', uri: 'u1', filename: 'a.jpg', width: 100, height: 200, size: 10 });
+          return Promise.resolve({
+            id: '1',
+            uri: 'u1',
+            filename: 'Screenshot_1.png',
+            width: 100,
+            height: 200,
+            size: 10,
+            mediaSubtypes: ['screenshot'],
+          });
         case '2':
-          return Promise.resolve({ id: '2', uri: 'u2', filename: 'b.jpg', width: 100, height: 200, size: 10 });
-        default:
+          return Promise.resolve({
+            id: '2',
+            uri: 'u2',
+            filename: 'IMG_selfie.jpg',
+            width: 100,
+            height: 200,
+            size: 10,
+          });
+        case '3':
           return Promise.resolve({ id: '3', uri: 'u3', filename: 'c.jpg', width: 200, height: 100, size: 5 });
+        default:
+          return Promise.resolve({ id: '4', uri: 'u4', filename: 'd.jpg', width: 100, height: 100, size: 3 });
       }
     });
 
     const result = await analyzePhotos();
     expect(result.byOrientation.portrait).toHaveLength(2);
     expect(result.byOrientation.landscape).toHaveLength(1);
+    expect(result.byOrientation.square).toHaveLength(1);
     // photos 1 and 2 have same dimensions and size -> duplicate group
     expect(result.duplicates).toHaveLength(1);
     expect(result.duplicates[0]).toHaveLength(2);
+    expect(result.screenshots).toHaveLength(1);
+    expect(result.selfies).toHaveLength(1);
   });
 
   it('reports progress during analysis', async () => {

--- a/app/(tabs)/analysis.tsx
+++ b/app/(tabs)/analysis.tsx
@@ -48,6 +48,12 @@ export default function AnalysisScreen() {
             <Text className="mb-1">
               Square: {result.byOrientation.square.length}
             </Text>
+            <Text className="mb-1">
+              Screenshots: {result.screenshots.length}
+            </Text>
+            <Text className="mb-1">
+              Selfies: {result.selfies.length}
+            </Text>
             <Text>Duplicate groups: {result.duplicates.length}</Text>
           </View>
         ) : (


### PR DESCRIPTION
## Summary
- add screenshot and selfie detection to photo analyzer
- display new categories on the Scan screen
- update tests for analyzer logic

## Testing
- `npm test`
- `npm run lint` *(fails: JSX parsing error)*
- `npm run format` *(fails: JSX parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_686de0b784e0832bb24fe9708500c1ae