### PR TITLE
Add photo categorization features

### DIFF
--- a/__tests__/photoAnalyzer.test.ts
+++ b/__tests__/photoAnalyzer.test.ts
@@ -29,6 +29,7 @@ describe('photoAnalyzer', () => {
             height: 200,
             size: 10,
             mediaSubtypes: ['screenshot'],
+            creationTime: Date.now(),
           });
         case '2':
           return Promise.resolve({
@@ -38,11 +39,28 @@ describe('photoAnalyzer', () => {
             width: 100,
             height: 200,
             size: 10,
+            creationTime: Date.now() - 366 * 24 * 60 * 60 * 1000,
           });
         case '3':
-          return Promise.resolve({ id: '3', uri: 'u3', filename: 'c.jpg', width: 200, height: 100, size: 5 });
+          return Promise.resolve({
+            id: '3',
+            uri: 'u3',
+            filename: 'c.jpg',
+            width: 200,
+            height: 100,
+            size: 5,
+            creationTime: Date.now(),
+          });
         default:
-          return Promise.resolve({ id: '4', uri: 'u4', filename: 'd.jpg', width: 100, height: 100, size: 3 });
+          return Promise.resolve({
+            id: '4',
+            uri: 'u4',
+            filename: 'd.jpg',
+            width: 100,
+            height: 100,
+            size: 3,
+            creationTime: Date.now(),
+          });
       }
     });
 
@@ -55,6 +73,8 @@ describe('photoAnalyzer', () => {
     expect(result.duplicates[0]).toHaveLength(2);
     expect(result.screenshots).toHaveLength(1);
     expect(result.selfies).toHaveLength(1);
+    expect(result.oldPhotos).toHaveLength(1);
+    expect(result.lowRes).toHaveLength(4);
   });
 
   it('reports progress during analysis', async () => {
@@ -69,6 +89,7 @@ describe('photoAnalyzer', () => {
       width: 100,
       height: 200,
       size: 5,
+      creationTime: Date.now(),
     });
 
     const progress: number[] = [];

--- a/app/(tabs)/analysis.tsx
+++ b/app/(tabs)/analysis.tsx
@@ -54,6 +54,8 @@ export default function AnalysisScreen() {
             <Text className="mb-1">
               Selfies: {result.selfies.length}
             </Text>
+            <Text className="mb-1">Old photos: {result.oldPhotos.length}</Text>
+            <Text className="mb-1">Low res: {result.lowRes.length}</Text>
             <Text>Duplicate groups: {result.duplicates.length}</Text>
           </View>
         ) : (
@@ -64,7 +66,7 @@ export default function AnalysisScreen() {
         {loading && (
           <View className="w-full my-4">
             <ProgressIndicator value={progress} />
-            <Text className="mt-2 text-center">{progress}%</Text>
+            <Text className="mt-2 text-center">Scanning: {progress}%</Text>
           </View>
         )}
         <Button onPress={handleScan} variant="primary" disabled={loading}>


### PR DESCRIPTION
## Summary
- categorize photos by age and resolution
- expose counts for new categories in the analysis screen
- update photo analyzer tests for new data

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686de5c5b60c832bb49c3f4962d606f0