### PR TITLE
Add amusement/horror theme

### DIFF
--- a/GAME_CUSTOMIZATION.md
+++ b/GAME_CUSTOMIZATION.md
@@ -57,6 +57,7 @@ in `lib/useCustomFonts.ts` and update the `fontFamily` entries in
 ## Colors and Theme
 - Adjust the color palette in `theme/colors.ts`.
 - Navigation theme values live in `theme/index.ts`.
+- Switch between `default`, `amusement`, and `horror` by editing `APP_THEME` in `theme/colors.ts`. Each theme provides unique confetti colors and gradients.
 
 ## XP Values
 - Edit `XP_CONFIG` in `store/store.ts` to tweak XP rewards and penalties.

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -8,8 +8,8 @@ export const Container = ({ children }: { children: React.ReactNode }) => {
   const { colorScheme } = useColorScheme();
   const colors =
     colorScheme === 'dark'
-      ? [COLORS.dark.background, COLORS.dark.grey6]
-      : [COLORS.light.background, COLORS.light.grey5];
+      ? [COLORS.dark.primary, COLORS.dark.background]
+      : [COLORS.light.primary, COLORS.light.background];
   return (
     <LinearGradient colors={colors} style={styles.gradient}>
       <SafeAreaView style={styles.container}>{children}</SafeAreaView>

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Alert, Dimensions, Pressable } from 'react-native';
 import ConfettiCannon from 'react-native-confetti-cannon';
+import { CONFETTI_COLORS } from '~/theme/colors';
 import { SwipeDeck, SwipeDeckItem } from './SwipeDeck';
 // Toast and achievement overlays removed for a cleaner interface
 import { ComboOverlay } from './ComboOverlay';
@@ -354,6 +355,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ className }) => {
           key={confettiKey}
           count={30}
           fadeOut
+          colors={CONFETTI_COLORS}
           origin={{ x: Dimensions.get('window').width / 2, y: 0 }}
         />
       )}

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -33,6 +33,94 @@ const ANDROID_COLORS = {
   },
 } as const;
 
-const COLORS = ANDROID_COLORS;
+const AMUSEMENT_COLORS = {
+  white: 'rgb(255, 255, 255)',
+  black: 'rgb(0, 0, 0)',
+  light: {
+    grey6: 'rgb(254, 247, 228)',
+    grey5: 'rgb(255, 235, 205)',
+    grey4: 'rgb(255, 215, 175)',
+    grey3: 'rgb(255, 190, 145)',
+    grey2: 'rgb(255, 165, 115)',
+    grey: 'rgb(85, 70, 70)',
+    background: 'rgb(254, 245, 230)',
+    foreground: 'rgb(60, 60, 60)',
+    root: 'rgb(254, 245, 230)',
+    card: 'rgb(255, 231, 210)',
+    destructive: 'rgb(255, 80, 80)',
+    primary: 'rgb(0, 170, 250)',
+    xp: 'rgb(255, 240, 70)',
+  },
+  dark: {
+    grey6: 'rgb(40, 40, 40)',
+    grey5: 'rgb(60, 60, 60)',
+    grey4: 'rgb(80, 80, 80)',
+    grey3: 'rgb(110, 110, 110)',
+    grey2: 'rgb(160, 160, 160)',
+    grey: 'rgb(200, 200, 200)',
+    background: 'rgb(20, 20, 20)',
+    foreground: 'rgb(235, 235, 235)',
+    root: 'rgb(20, 20, 20)',
+    card: 'rgb(40, 40, 40)',
+    destructive: 'rgb(255, 80, 80)',
+    primary: 'rgb(0, 170, 250)',
+    xp: 'rgb(255, 240, 70)',
+  },
+} as const;
 
-export { COLORS };
+const HORROR_COLORS = {
+  white: 'rgb(240, 240, 240)',
+  black: 'rgb(0, 0, 0)',
+  light: {
+    grey6: 'rgb(245, 240, 240)',
+    grey5: 'rgb(220, 220, 220)',
+    grey4: 'rgb(200, 190, 190)',
+    grey3: 'rgb(170, 160, 160)',
+    grey2: 'rgb(130, 120, 120)',
+    grey: 'rgb(80, 70, 70)',
+    background: 'rgb(250, 245, 245)',
+    foreground: 'rgb(50, 20, 20)',
+    root: 'rgb(250, 245, 245)',
+    card: 'rgb(230, 220, 220)',
+    destructive: 'rgb(180, 0, 0)',
+    primary: 'rgb(75, 0, 130)',
+    xp: 'rgb(245, 220, 80)',
+  },
+  dark: {
+    grey6: 'rgb(30, 20, 20)',
+    grey5: 'rgb(40, 30, 30)',
+    grey4: 'rgb(60, 40, 40)',
+    grey3: 'rgb(80, 60, 60)',
+    grey2: 'rgb(110, 85, 85)',
+    grey: 'rgb(160, 140, 140)',
+    background: 'rgb(15, 10, 10)',
+    foreground: 'rgb(220, 220, 220)',
+    root: 'rgb(15, 10, 10)',
+    card: 'rgb(35, 25, 25)',
+    destructive: 'rgb(200, 0, 0)',
+    primary: 'rgb(120, 0, 150)',
+    xp: 'rgb(245, 220, 80)',
+  },
+} as const;
+
+export const APP_THEME = 'amusement' as const;
+
+const THEMES = {
+  default: { colors: ANDROID_COLORS, confetti: ['#f72585', '#ffd166', '#04a9f4'] },
+  amusement: {
+    colors: AMUSEMENT_COLORS,
+    confetti: ['#ff80ab', '#ffd740', '#69f0ae', '#536dfe'],
+  },
+  horror: {
+    colors: HORROR_COLORS,
+    confetti: ['#b00020', '#ffffff', '#7209b7'],
+  },
+} as const;
+
+type ThemeName = keyof typeof THEMES;
+const ACTIVE_THEME: ThemeName = APP_THEME;
+
+const COLORS = THEMES[ACTIVE_THEME].colors;
+const CONFETTI_COLORS = THEMES[ACTIVE_THEME].confetti;
+
+export { COLORS, CONFETTI_COLORS };


### PR DESCRIPTION
## Summary
- implement theme selector in `theme/colors.ts`
- update gradient backgrounds in `Container`
- colorize confetti bursts using new theme colors
- document theme switching in `GAME_CUSTOMIZATION.md`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e442bef2c832b9b97a52dcb56fae0