### PR TITLE
Add Zen Mode toggle and theme docs

### DIFF
--- a/MASCOT_README.md
+++ b/MASCOT_README.md
@@ -15,3 +15,12 @@ The game features a playful mascot that appears during level-up events and onboa
 - Keep the sprite sheet minimal (3–4 frames) so it performs well on low-end devices
 
 The mascot does not need to match Flappy Bird exactly—use it as a baseline for proportions and movement. A few color tweaks or accessories can help it feel unique to DeCluttr.
+
+## Themed Variations
+
+Feel free to reskin the bird for different moods:
+
+- **Carnival Barker** – add a little hat and bright stripes for a friendly, inviting feel.
+- **Spooky Ghost** – replace the bird with a simple ghost sprite for a cult horror vibe.
+
+When you change the mascot, consider swapping the sound effects in `assets/sounds/` as well. Cheerful splashes or eerie beeps help sell each theme.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ give instant feedback as soon as you start swiping so the game feels snappy and 
 10. Subtle haptic feedback triggers on each swipe for extra game feel.
 11. A small header widget shows your **level** and XP with a progress bar that fills as you get closer to leveling up.
 12. Specify a favicon path for the web in `app.json` under `expo.web.favicon`.
-13. Enable **Zen Mode** from the gallery screen to hide stats and confetti for a stress-free experience.
+13. Enable **Zen Mode** from the gallery screen to hide XP and other stats while still showing confetti for a more immersive vibe.
 
 ## Running the App on Android
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { View } from 'react-native';
 import { useRecycleBinStore } from '~/store/store';
 import { AudioToggle } from '~/components/AudioToggle';
+import { ZenToggle } from '~/components/ZenToggle';
 
 function RecycleBinTabIcon({ color, size }: { color: string; size: number }) {
   const { deletedPhotos } = useRecycleBinStore();
@@ -24,7 +25,8 @@ export default function TabLayout() {
         headerShown: true,
         headerTitle: '',
         headerRight: () => (
-          <View className="flex-row items-center gap-2 mr-1">
+          <View className="mr-1 flex-row items-center gap-2">
+            <ZenToggle />
             <AudioToggle />
           </View>
         ),

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,8 +30,14 @@ export default function RootLayout() {
   useInitialAndroidBarSync();
   const { colorScheme, isDarkColorScheme } = useColorScheme();
   const fontsLoaded = useCustomFonts();
-  const { loadXP, loadDeletedPhotos, loadTotalDeleted, isXpLoaded, checkOnboardingStatus } =
-    useRecycleBinStore();
+  const {
+    loadXP,
+    loadDeletedPhotos,
+    loadTotalDeleted,
+    isXpLoaded,
+    checkOnboardingStatus,
+    loadZenMode,
+  } = useRecycleBinStore();
   const segments = useSegments();
   const router = useRouter();
 
@@ -41,8 +47,9 @@ export default function RootLayout() {
       loadXP();
       loadDeletedPhotos();
       loadTotalDeleted();
+      loadZenMode();
     }
-  }, [loadXP, loadDeletedPhotos, loadTotalDeleted, isXpLoaded]);
+  }, [loadXP, loadDeletedPhotos, loadTotalDeleted, loadZenMode, isXpLoaded]);
 
   // Check onboarding status only once on startup to avoid
   // repeated AsyncStorage reads when navigating between screens

--- a/assets/sounds/README.md
+++ b/assets/sounds/README.md
@@ -27,6 +27,7 @@ The included files are silent placeholders. Provide your own voice clips to use 
 - **delete.mp3**: Short "zap" or "whoosh" effect for a playful feel
 - **keep.mp3**: Pleasant "ding" or "chime" that rewards the swipe
 - For a retro vibe, keep the clips under half a second and use 8‑bit samples reminiscent of classic Nintendo games
+- When customizing mascot themes (see `MASCOT_README.md`), adjust the sounds to match. A carnival style might use water splashes or whistles, while a ghost theme could feature eerie beeps.
 
 ## How to Add Sounds:
 

--- a/components/ZenToggle.tsx
+++ b/components/ZenToggle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRecycleBinStore } from '~/store/store';
+import { px } from '~/lib/pixelPerfect';
+
+export const ZenToggle: React.FC = () => {
+  const { zenMode, setZenMode } = useRecycleBinStore();
+
+  const toggle = () => {
+    setZenMode(!zenMode);
+  };
+
+  return (
+    <Pressable onPress={toggle} className="p-1">
+      <Ionicons
+        name={zenMode ? 'eye-off' : 'eye'}
+        size={px(16)}
+        color="rgb(var(--android-primary))"
+      />
+    </Pressable>
+  );
+};
+
+export default ZenToggle;


### PR DESCRIPTION
## Summary
- persist zen mode preference in store
- add ZenToggle component and hook up in tab layout
- load zen mode from AsyncStorage
- update mascot readme with themed variations
- mention themed sound effects
- update README with new zen mode description

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ea1978a1c832b8cfeb443975cfca2