### PR TITLE
Add album sorting button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DeCluttr
 
 A minimal photo clean-up game for Android built with Expo React Native. A small bird mascot celebrates your progress as you swipe photos left or right.
+You can also move a photo into any album using the folder button.
 
 Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 - Add video review support.
 
 ## Long Term
-- Mark images as favourites or move/copy them to another album.
+- ~~Mark images as favourites or move/copy them to another album.~~ Done: photos can now be moved to any album via the new folder button.
 - Exclude or include specific albums during review.
 - Detect and remove duplicate images.
 - Share images without captions or as documents.


### PR DESCRIPTION
## Summary
- let players move photos into a chosen album
- expose `fetchAlbums` and `moveAssetToAlbum` helpers
- show Move button next to Reset button
- document new feature in README and TODO

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ec448e638832b8cbd96e073b31164