### PR TITLE
Add CI setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ You can also move a photo into any album using the folder button.
 
 Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
 
-See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, and XP.
+See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, XP, and CI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ docs/
 ├── audio.md       # sound system overview
 ├── mascot.md      # mascot assets
 ├── onboarding.md  # onboarding flow
+├── ci.md          # CI setup
 └── xp.md          # XP tracking
 ```
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,7 @@
+# Continuous Integration Setup
+
+Set up CI with GitHub Actions to run lint and test steps on every push. Use `node:20` as the container image and install dependencies via `npm ci`.
+
+Create `.github/workflows/test.yml` with jobs for `lint` and `test`. Each job checks out code, installs Node, caches dependencies and runs `npm run lint` or `npm test`.
+
+Include status badges in the main `README.md` once the workflow is active.


### PR DESCRIPTION
## Summary
- document basic CI workflow using GitHub Actions
- link to CI docs from main README
- update docs overview with the new file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ee2166fa0832bb6f6361a43b292ae