### PR TITLE
Add zen mode docs and skip XP updates

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -35,6 +35,7 @@ describe('RecycleBin store', () => {
       xp: 0,
       isXpLoaded: true,
       onboardingCompleted: false,
+      zenMode: false,
     });
   });
 
@@ -155,6 +156,15 @@ describe('RecycleBin store', () => {
     await store.subtractXP(5);
     expect(useRecycleBinStore.getState().xp).toBe(5);
     await store.subtractXP(20);
+    expect(useRecycleBinStore.getState().xp).toBe(0);
+  });
+
+  it('skips XP changes when zen mode is active', async () => {
+    useRecycleBinStore.setState({ zenMode: true });
+    const store = useRecycleBinStore.getState();
+    await store.addXP(10);
+    expect(useRecycleBinStore.getState().xp).toBe(0);
+    await store.subtractXP(5);
     expect(useRecycleBinStore.getState().xp).toBe(0);
   });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ docs/
 ├── onboarding.md  # onboarding flow
 ├── ci.md          # CI setup
 ├── video.md       # handling video assets
-└── xp.md          # XP tracking
+├── xp.md          # XP tracking
+└── zen.md         # distraction-free play
 ```
 
 Each file is under three short paragraphs for quick reference.

--- a/docs/zen.md
+++ b/docs/zen.md
@@ -1,0 +1,5 @@
+Zen mode hides XP counters and level displays so players can clean photos without distraction. The toggle sits in the header via the `ZenToggle` component and uses the `zenMode` flag in the store.
+
+While enabled, XP functions early-return so progress numbers stay constant. This keeps the game simple but still lets you re-enable XP later without data loss.
+
+The flag persists in AsyncStorage. Modify the store if you also want to pause audio or achievements when zen mode is active.

--- a/store/store.ts
+++ b/store/store.ts
@@ -169,7 +169,10 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   // Add XP and save to storage
   addXP: async (amount: number) => {
     try {
-      const { xp } = get();
+      const { xp, zenMode } = get();
+      if (zenMode) {
+        return;
+      }
       const newXP = Math.max(0, xp + amount); // Prevent negative XP
       set({ xp: newXP });
 
@@ -184,7 +187,10 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   // Subtract XP and save to storage
   subtractXP: async (amount: number) => {
     try {
-      const { xp } = get();
+      const { xp, zenMode } = get();
+      if (zenMode) {
+        return;
+      }
       const newXP = Math.max(0, xp - amount); // Prevent negative XP
       set({ xp: newXP });
 


### PR DESCRIPTION
## Summary
- document Zen mode
- add Zen mode bullet in docs table
- skip XP updates when zen mode is enabled
- test XP logic in zen mode

## Testing
- `npm run format` *(fails: Cannot find module 'eslint/config')*
- `npm test`
- `npm run lint` *(warns about code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6870b2a11ed4832ba9f1e56f2c264c5d