### PR TITLE
Add WhatsApp tab and album support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A minimal photo clean-up game for Android built with Expo React Native. A small bird mascot celebrates your progress as you swipe photos left or right.
 You can also move a photo into any album using the folder button.
+A new WhatsApp tab lets you review images from the WhatsApp Images album.
 
 Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -53,6 +53,14 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="whatsapp"
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="logo-whatsapp" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="recycle-bin"
         options={{
           tabBarIcon: ({ color, size }) => <RecycleBinTabIcon color={color} size={size} />,

--- a/app/(tabs)/whatsapp.tsx
+++ b/app/(tabs)/whatsapp.tsx
@@ -1,0 +1,14 @@
+import { Stack } from 'expo-router';
+import { Container } from '~/components/Container';
+import { PhotoGallery } from '~/components/PhotoGallery';
+
+export default function WhatsAppPhotos() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <Container>
+        <PhotoGallery albumName="WhatsApp Images" />
+      </Container>
+    </>
+  );
+}

--- a/lib/mediaLibrary.ts
+++ b/lib/mediaLibrary.ts
@@ -463,7 +463,7 @@ export async function fetchAssetsFromAlbumWithPagination(
   albumName: string,
   after?: string,
   first: number = 20,
-  mediaType: MediaLibrary.MediaType = MediaLibrary.MediaType.photo
+  mediaType: MediaLibrary.MediaTypeValue = MediaLibrary.MediaType.photo
 ): Promise<{
   assets: PhotoAsset[];
   hasNextPage: boolean;


### PR DESCRIPTION
## Summary
- support filtering PhotoGallery by album
- add WhatsApp tab using the new album feature
- document WhatsApp tab in README
- fix type for fetchAssetsFromAlbumWithPagination

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68710941cee8832bac70cf3a151bad1e