### PR TITLE
Add album picker

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Short Term
  - Clarify delete behaviour: photos are always permanently removed.
-- Add advanced folder selection including WhatsApp media scanning.
+- ~~Add advanced folder selection including WhatsApp media scanning.~~ Done: Albums tab lets you browse any album, including WhatsApp folders.
 - Provide multi-select delete and bulk removal by month or album.
 - Improve selection workflow:
   - Change default swipe actions to navigation.

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -61,6 +61,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="albums"
+        options={{
+          tabBarIcon: ({ color, size }) => <Ionicons name="images" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="recycle-bin"
         options={{
           tabBarIcon: ({ color, size }) => <RecycleBinTabIcon color={color} size={size} />,

--- a/app/(tabs)/albums.tsx
+++ b/app/(tabs)/albums.tsx
@@ -1,0 +1,47 @@
+import { Stack, useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { View, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { Container } from '~/components/Container';
+import { Text } from '~/components/nativewindui/Text';
+import { fetchAlbums, MediaAlbum } from '~/lib/mediaLibrary';
+
+export default function Albums() {
+  const [albums, setAlbums] = useState<MediaAlbum[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetchAlbums()
+      .then(setAlbums)
+      .catch((err) => {
+        console.error('Failed to load albums', err);
+        Alert.alert('Error', 'Failed to load albums.');
+      });
+  }, []);
+
+  const handleSelect = (album: MediaAlbum) => {
+    router.push({ pathname: '/album/[name]', params: { name: album.title } });
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Albums' }} />
+      <Container>
+        <ScrollView className="flex-1 py-4" contentContainerStyle={{ paddingBottom: 40 }}>
+          {albums.map((album) => (
+            <TouchableOpacity
+              key={album.id}
+              onPress={() => handleSelect(album)}
+              className="mb-4 rounded-md border border-border p-4">
+              <Text>{album.title}</Text>
+            </TouchableOpacity>
+          ))}
+          {albums.length === 0 && (
+            <View className="flex-1 items-center justify-center">
+              <Text color="secondary">No albums found</Text>
+            </View>
+          )}
+        </ScrollView>
+      </Container>
+    </>
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -101,6 +101,7 @@ export default function RootLayout() {
                   options={{ headerShown: false, gestureEnabled: false }}
                 />
                 <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                <Stack.Screen name="album/[name]" options={{ headerShown: false }} />
               </Stack>
             </NavThemeProvider>
           </ActionSheetProvider>

--- a/app/album/[name].tsx
+++ b/app/album/[name].tsx
@@ -1,0 +1,16 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { Container } from '~/components/Container';
+import { PhotoGallery } from '~/components/PhotoGallery';
+
+export default function AlbumGallery() {
+  const { name } = useLocalSearchParams<{ name: string }>();
+  const albumName = Array.isArray(name) ? name[0] : name;
+  return (
+    <>
+      <Stack.Screen options={{ title: albumName }} />
+      <Container>
+        <PhotoGallery albumName={albumName} />
+      </Container>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add Albums screen for selecting any media album, including WhatsApp
- add dynamic album/[name] route to show a PhotoGallery for that album
- expose Albums tab in the tab bar
- wire album route in root layout
- mark folder selection TODO item as complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68738303a110832b905090f34bbd8899