### PR TITLE
Add Quicksand font as default

### DIFF
--- a/GAME_CUSTOMIZATION.md
+++ b/GAME_CUSTOMIZATION.md
@@ -4,7 +4,7 @@ This guide summarizes the key files to modify when you want to personalize the g
 
 ## Fonts and Typography
 
-DeCluttr ships with the classic arcade typeface **"Press Start 2P"** alongside Inter.
+DeCluttr ships with the classic arcade typeface **"Press Start 2P"** alongside Quicksand.
 The fonts are loaded with Expo's font utilities and exposed via Tailwind so you can
 easily reference them in your components.
 
@@ -16,11 +16,12 @@ easily reference them in your components.
 
   ```ts
   import { PressStart2P_400Regular } from '@expo-google-fonts/press-start-2p';
+  import { Quicksand_400Regular, Quicksand_700Bold } from '@expo-google-fonts/quicksand';
 
   export function useCustomFonts() {
     const [loaded] = useFonts({
-      Inter_400Regular,
-      Inter_700Bold,
+      Quicksand_400Regular,
+      Quicksand_700Bold,
       PressStart2P_400Regular,
       VT323_400Regular,
       Bungee_400Regular,
@@ -37,7 +38,7 @@ easily reference them in your components.
 
   ```js
   fontFamily: {
-    sans: ['Inter', 'System', 'sans-serif'],
+    sans: ['Quicksand_400Regular', 'System', 'sans-serif'],
     arcade: ['"PressStart2P_400Regular"', 'Inter', 'System', 'sans-serif'],
     celeste: ['"VT323"', 'monospace'],
     funky: ['"Bungee"', 'sans-serif'],

--- a/components/nativewindui/Text.tsx
+++ b/components/nativewindui/Text.tsx
@@ -50,8 +50,8 @@ const fontSizes = {
   caption2: px(11),
 } as const;
 
-// Default to the arcade font so all text uses "Press Start 2P"
-const TextClassContext = React.createContext<string | undefined>('font-arcade');
+// Default to the sans font family (Quicksand)
+const TextClassContext = React.createContext<string | undefined>('font-sans');
 
 function Text({
   className,

--- a/lib/useCustomFonts.ts
+++ b/lib/useCustomFonts.ts
@@ -4,6 +4,7 @@ import { PressStart2P_400Regular } from '@expo-google-fonts/press-start-2p';
 import { VT323_400Regular } from '@expo-google-fonts/vt323';
 import { Bungee_400Regular } from '@expo-google-fonts/bungee';
 import { UnifrakturCook_700Bold } from '@expo-google-fonts/unifrakturcook';
+import { Quicksand_400Regular, Quicksand_700Bold } from '@expo-google-fonts/quicksand';
 
 export function useCustomFonts() {
   const [loaded] = useFonts({
@@ -13,6 +14,8 @@ export function useCustomFonts() {
     VT323_400Regular,
     Bungee_400Regular,
     UnifrakturCook_700Bold,
+    Quicksand_400Regular,
+    Quicksand_700Bold,
   });
   return loaded;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo-google-fonts/bungee": "^0.3.0",
         "@expo-google-fonts/inter": "^0.3.0",
         "@expo-google-fonts/press-start-2p": "^0.3.0",
+        "@expo-google-fonts/quicksand": "^0.2.3",
         "@expo-google-fonts/unifrakturcook": "^0.3.0",
         "@expo-google-fonts/vt323": "^0.3.0",
         "@expo/react-native-action-sheet": "^4.1.1",
@@ -1979,6 +1980,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/press-start-2p/-/press-start-2p-0.3.0.tgz",
       "integrity": "sha512-r6c12zSXVhgtrOCOrZ5r3YM5PHTakQ1EsqNffTXpBV3t4/VYT13HQ3lGpo8nNHY+RcMTNyNs0gnyN6N/BK+/2A==",
+      "license": "MIT"
+    },
+    "node_modules/@expo-google-fonts/quicksand": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/quicksand/-/quicksand-0.2.3.tgz",
+      "integrity": "sha512-cQhYsOYPBbKzqry0TT87fJz8ZlCKLLeHiECsjI9zRx4pMB3XKnHSWNO7JBDvMA6w9ekcQ17aaBZ4vj9RC2Kgtw==",
       "license": "MIT"
     },
     "node_modules/@expo-google-fonts/unifrakturcook": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@expo-google-fonts/bungee": "^0.3.0",
     "@expo-google-fonts/inter": "^0.3.0",
     "@expo-google-fonts/press-start-2p": "^0.3.0",
+    "@expo-google-fonts/quicksand": "^0.2.3",
     "@expo-google-fonts/unifrakturcook": "^0.3.0",
     "@expo-google-fonts/vt323": "^0.3.0",
     "@expo/react-native-action-sheet": "^4.1.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   theme: {
     extend: {
   fontFamily: {
-        sans: ['Inter', 'System', 'sans-serif'],
+        sans: ['Quicksand_400Regular', 'System', 'sans-serif'],
         // Use the Expo font name for Press Start 2P
         arcade: ['"PressStart2P_400Regular"', 'Inter', 'System', 'sans-serif'],
         celeste: ['"VT323"', 'monospace'],


### PR DESCRIPTION
## Summary
- load Quicksand fonts in the app
- use Quicksand as default sans font in Tailwind
- update Text component default font
- document updated font setup
- add Quicksand font package

## Testing
- `npm run format`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687384f7f1b8832b81de5c7310b77b20