### PR TITLE
Simplify gameplay by removing XP

### DIFF
--- a/GAME_CUSTOMIZATION.md
+++ b/GAME_CUSTOMIZATION.md
@@ -60,9 +60,6 @@ in `lib/useCustomFonts.ts` and update the `fontFamily` entries in
 - Navigation theme values live in `theme/index.ts`.
 - Switch between `default`, `amusement`, and `horror` by editing `APP_THEME` in `theme/colors.ts`. Each theme provides unique confetti colors and gradients.
 
-## XP Values
-- Edit `XP_CONFIG` in `store/store.ts` to tweak XP rewards and penalties.
-
 ## Positive Messages
 - Modify phrases in `lib/positiveMessages.ts` to change the short encouragement banners.
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A new WhatsApp tab lets you review images from the WhatsApp Images album.
 
 Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
 
-See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, XP, and CI.
+See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, and CI.

--- a/XP_SYSTEM_README.md
+++ b/XP_SYSTEM_README.md
@@ -1,7 +1,0 @@
-# XP System
-
-Deleting and restoring photos awards or removes XP. Every 100 XP increases your level, tracked in the header and stats screen.
-
-XP is stored with AsyncStorage via the Zustand store in `store/store.ts`. Photo actions automatically update the total so most components don't need to call XP functions directly.
-
-You can tune the reward amounts in `XP_CONFIG` inside the store file to fit new game modes.

--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -1,4 +1,4 @@
-import { useRecycleBinStore, XP_CONFIG, DeletedPhoto } from '../store/store';
+import { useRecycleBinStore, DeletedPhoto } from '../store/store';
 import * as mediaLibrary from '../lib/mediaLibrary';
 
 jest.mock('../lib/asyncStorageWrapper', () => {
@@ -32,27 +32,22 @@ describe('RecycleBin store', () => {
     useRecycleBinStore.setState({
       deletedPhotos: [],
       totalDeleted: 0,
-      xp: 0,
-      isXpLoaded: true,
       onboardingCompleted: false,
       zenMode: false,
     });
   });
 
-  it('adds and restores photos with XP updates', async () => {
+  it('adds and restores photos', async () => {
     const { addDeletedPhoto, restorePhoto } = useRecycleBinStore.getState();
     const photo = createPhoto('1');
     addDeletedPhoto(photo);
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
     expect(useRecycleBinStore.getState().totalDeleted).toBe(1);
-    expect(useRecycleBinStore.getState().xp).toBe(XP_CONFIG.DELETE_PHOTO);
     expect(mediaLibrary.deletePhotoAsset).not.toHaveBeenCalled();
 
     const restored = restorePhoto('1');
     expect(restored).toEqual(photo);
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
-    expect(useRecycleBinStore.getState().xp).toBe(XP_CONFIG.DELETE_PHOTO + XP_CONFIG.RESTORE_PHOTO);
-    expect(mediaLibrary.deletePhotoAsset).not.toHaveBeenCalled();
   });
 
   it('permanently deletes photos and clears recycle bin', async () => {
@@ -65,22 +60,16 @@ describe('RecycleBin store', () => {
     await expect(clearRecycleBin()).resolves.toBe(true);
     expect(mediaLibrary.deletePhotoAssets).toHaveBeenCalledWith(['2']);
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
-    expect(useRecycleBinStore.getState().xp).toBe(
-      XP_CONFIG.DELETE_PHOTO * 2 + XP_CONFIG.PERMANENT_DELETE + XP_CONFIG.CLEAR_ALL
-    );
   });
 
-  it('keeps photo and XP unchanged when permanent delete fails', async () => {
+  it('keeps photo when permanent delete fails', async () => {
     const { addDeletedPhoto, permanentlyDelete } = useRecycleBinStore.getState();
     addDeletedPhoto(createPhoto('1'));
     (mediaLibrary.deletePhotoAsset as jest.Mock).mockResolvedValueOnce(false);
 
     await expect(permanentlyDelete('1')).resolves.toBe(false);
 
-    // Photo should remain because deletion failed
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
-    // XP should not include permanent delete reward
-    expect(useRecycleBinStore.getState().xp).toBe(XP_CONFIG.DELETE_PHOTO);
   });
 
   it('purges expired photos', async () => {
@@ -105,8 +94,6 @@ describe('RecycleBin store', () => {
     await expect(clearRecycleBin()).resolves.toBe(false);
 
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(2);
-    // XP should only reflect initial deletes
-    expect(useRecycleBinStore.getState().xp).toBe(XP_CONFIG.DELETE_PHOTO * 2);
   });
 
   it('keeps expired photos when purge deletion fails', async () => {
@@ -126,46 +113,23 @@ describe('RecycleBin store', () => {
     await store.resetGallery();
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
     expect(useRecycleBinStore.getState().totalDeleted).toBe(0);
-    expect(useRecycleBinStore.getState().xp).toBe(0);
     await store.resetOnboarding();
     expect(useRecycleBinStore.getState().onboardingCompleted).toBe(false);
   });
-  it('loads xp and deleted photos from storage', async () => {
+
+  it('loads deleted photos from storage', async () => {
     const { getAsyncStorage } = await import('../lib/asyncStorageWrapper');
     const storage = getAsyncStorage();
-    await storage.setItem('@decluttr_xp', '15');
     await storage.setItem('@decluttr_deleted_photos', JSON.stringify([createPhoto('a')]));
     await storage.setItem('@decluttr_total_deleted', '5');
     useRecycleBinStore.setState({
       deletedPhotos: [],
-      xp: 0,
-      isXpLoaded: false,
       onboardingCompleted: false,
     });
-    await useRecycleBinStore.getState().loadXP();
     await useRecycleBinStore.getState().loadDeletedPhotos();
     await useRecycleBinStore.getState().loadTotalDeleted();
-    expect(useRecycleBinStore.getState().xp).toBe(15);
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
     expect(useRecycleBinStore.getState().totalDeleted).toBe(5);
-  });
-
-  it('addXP and subtractXP clamp at zero', async () => {
-    const store = useRecycleBinStore.getState();
-    await store.addXP(10);
-    await store.subtractXP(5);
-    expect(useRecycleBinStore.getState().xp).toBe(5);
-    await store.subtractXP(20);
-    expect(useRecycleBinStore.getState().xp).toBe(0);
-  });
-
-  it('skips XP changes when zen mode is active', async () => {
-    useRecycleBinStore.setState({ zenMode: true });
-    const store = useRecycleBinStore.getState();
-    await store.addXP(10);
-    expect(useRecycleBinStore.getState().xp).toBe(0);
-    await store.subtractXP(5);
-    expect(useRecycleBinStore.getState().xp).toBe(0);
   });
 
   it('onboarding status persists', async () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,26 +30,17 @@ export default function RootLayout() {
   useInitialAndroidBarSync();
   const { colorScheme, isDarkColorScheme } = useColorScheme();
   const fontsLoaded = useCustomFonts();
-  const {
-    loadXP,
-    loadDeletedPhotos,
-    loadTotalDeleted,
-    isXpLoaded,
-    checkOnboardingStatus,
-    loadZenMode,
-  } = useRecycleBinStore();
+  const { loadDeletedPhotos, loadTotalDeleted, checkOnboardingStatus, loadZenMode } =
+    useRecycleBinStore();
   const segments = useSegments();
   const router = useRouter();
 
-  // Load XP from AsyncStorage on app startup
+  // Load persisted data on startup
   useEffect(() => {
-    if (!isXpLoaded) {
-      loadXP();
-      loadDeletedPhotos();
-      loadTotalDeleted();
-      loadZenMode();
-    }
-  }, [loadXP, loadDeletedPhotos, loadTotalDeleted, loadZenMode, isXpLoaded]);
+    loadDeletedPhotos();
+    loadTotalDeleted();
+    loadZenMode();
+  }, [loadDeletedPhotos, loadTotalDeleted, loadZenMode]);
 
   // Check onboarding status only once on startup to avoid
   // repeated AsyncStorage reads when navigating between screens
@@ -72,14 +63,14 @@ export default function RootLayout() {
 
   // Start background music once fonts and storage are ready
   useEffect(() => {
-    if (fontsLoaded && isXpLoaded) {
+    if (fontsLoaded) {
       backgroundMusicService.play();
       audioService.initialize().catch(() => {});
     }
     return () => {
       backgroundMusicService.stop();
     };
-  }, [fontsLoaded, isXpLoaded]);
+  }, [fontsLoaded]);
 
   if (!fontsLoaded) {
     return null;

--- a/components/TurboOverlay.tsx
+++ b/components/TurboOverlay.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withRepeat, withTiming } from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+
+export const TurboOverlay: React.FC = () => {
+  const scale = useSharedValue(1);
+
+  useEffect(() => {
+    scale.value = withRepeat(withTiming(1.1, { duration: 200 }), -1, true);
+  }, [scale]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, styles.center, style]}>
+      <Text className="font-arcade text-4xl text-[rgb(var(--android-primary))]">TURBO!</Text>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default TurboOverlay;

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,6 @@ docs/
 ├── onboarding.md  # onboarding flow
 ├── ci.md          # CI setup
 ├── video.md       # handling video assets
-├── xp.md          # XP tracking
 └── zen.md         # distraction-free play
 ```
 

--- a/docs/enhancement_proposal.md
+++ b/docs/enhancement_proposal.md
@@ -4,8 +4,8 @@ This proposal outlines new features to make Declutr more engaging while staying 
 
 The bird mascot gains extra sprite sheets: a quick celebratory spin when you hit milestones like 10 photos cleared, a playful wink after moving a video, and a sleepy bob if the app is idle for a while. Animations swap in automatically with the current theme and use the same silent fallbacks as other assets, so missing files never crash the game.
 
-Rewards rely on the current XP system. Confetti and a stronger vibration fire on level-ups or every 50 photos deleted. No new numbers appear—zen mode continues to hide the XP bar entirely—so the UI stays uncluttered. A short milestone jingle accompanies major rewards, loaded through `audioService` with the usual mock players.
+Rewards rely only on visual and haptic feedback. Confetti and a stronger vibration fire every 50 photos deleted. No numbers appear—zen mode keeps the interface uncluttered. A short milestone jingle accompanies major rewards, loaded through `audioService` with the usual mock players.
 
 The UI keeps just the swipe deck, mascot, folder button and progress bar. Swipes glide smoothly with subtle fades, and milestone celebrations add vibrant confetti for a polished feel. Theme folders like `nature` introduce fresh mascot colors and matching sounds, all persisted via the existing store.
 
-Implementation touches only a few modules: extra animations live under `assets/mascot/<theme>/`, new sounds go in `assets/sounds/`, and minor logic updates occur in `components/SwipeDeck.tsx` and `store/store.ts` to trigger effects. Zustand persistence and AsyncStorage continue handling XP and settings to avoid new state bugs. The audio service's silent mock approach ensures any missing files fail gracefully.
+Implementation touches only a few modules: extra animations live under `assets/mascot/<theme>/`, new sounds go in `assets/sounds/`, and minor logic updates occur in `components/SwipeDeck.tsx` and `store/store.ts` to trigger effects. Zustand persistence and AsyncStorage continue handling settings to avoid new state bugs. The audio service's silent mock approach ensures any missing files fail gracefully.

--- a/docs/xp.md
+++ b/docs/xp.md
@@ -1,3 +1,0 @@
-Every photo action grants or subtracts XP. The totals are persisted in `store/store.ts` and leveling occurs every 100 XP.
-
-UI components read from the store to display current XP and level. Modify `XP_CONFIG` in the store file to change reward values.

--- a/docs/zen.md
+++ b/docs/zen.md
@@ -1,5 +1,5 @@
-Zen mode hides XP counters and level displays so players can clean photos without distraction. The toggle sits in the header via the `ZenToggle` component and uses the `zenMode` flag in the store.
+Zen mode hides progress counters so players can clean photos without distraction. The toggle sits in the header via the `ZenToggle` component and uses the `zenMode` flag in the store.
 
-While enabled, XP functions early-return so progress numbers stay constant. This keeps the game simple but still lets you re-enable XP later without data loss.
+Progress numbers are not tracked while zen mode is active. The flag persists in storage so it stays enabled across sessions.
 
 The flag persists in AsyncStorage. Modify the store if you also want to pause audio or achievements when zen mode is active.


### PR DESCRIPTION
## Summary
- drop XP system in store and remove XP docs
- update layout and gallery to run without XP logic
- add fun `TurboOverlay` animation when turbo mode is active
- trim surprise messages and adjust docs
- update tests for XP-less store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687396a8bf68832ba83fc80f50875a05