### PR TITLE
Add bird flock combo effect

### DIFF
--- a/MASCOT_README.md
+++ b/MASCOT_README.md
@@ -1,6 +1,6 @@
 # Mascot Design
 
-A tiny bird cheers players whenever they level up. Keep each sprite sheet small and colorful so animations stay snappy on low-end devices.
+A tiny bird cheers players during milestones like long swipe combos. Keep each sprite sheet small and colorful so animations stay snappy on low-end devices.
 
 Sprite frames live in `assets/mascot/<theme>/` with folders for `default`, `amusement`, and `horror`. Swap PNG sequences in these folders and toggle `APP_THEME` to change the look.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeCluttr
 
-A minimal photo clean-up game for Android built with Expo React Native. A small bird mascot celebrates your progress as you swipe photos left or right.
+A minimal photo clean-up game for Android built with Expo React Native. A small bird mascot celebrates your progress as you swipe photos left or right. Long delete streaks unleash a playful flock animation for extra flair.
 You can also move a photo into any album using the folder button.
 A new WhatsApp tab lets you review images from the WhatsApp Images album.
 

--- a/components/FlockOverlay.tsx
+++ b/components/FlockOverlay.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { Dimensions, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSequence,
+  withDelay,
+  Easing,
+} from 'react-native-reanimated';
+import { Text } from '~/components/nativewindui/Text';
+
+interface FlockOverlayProps {
+  onDone?: () => void;
+}
+
+const BIRD_COUNT = 5;
+
+export const FlockOverlay: React.FC<FlockOverlayProps> = ({ onDone }) => {
+  const screenWidth = Dimensions.get('window').width;
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withDelay(
+      100,
+      withSequence(
+        withTiming(1, { duration: 800, easing: Easing.out(Easing.quad) }),
+        withTiming(2, { duration: 100, easing: Easing.linear }, () => {
+          onDone?.();
+        })
+      )
+    );
+  }, [progress, onDone]);
+
+  const birds = new Array(BIRD_COUNT).fill(0).map((_, i) => {
+    const style = useAnimatedStyle(() => ({
+      position: 'absolute',
+      bottom: i * 10,
+      left: -30,
+      transform: [
+        {
+          translateX: (progress.value - i * 0.1) * screenWidth,
+        },
+        {
+          translateY: Math.sin(progress.value * 6 + i) * 20,
+        },
+      ],
+      opacity: progress.value < 1 ? 1 : 0,
+    }));
+    return (
+      <Animated.Text key={i} style={[styles.bird, style]}>
+        🐦
+      </Animated.Text>
+    );
+  });
+
+  return (
+    <Animated.View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {birds}
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  bird: {
+    fontSize: 24,
+  },
+});
+
+export default FlockOverlay;

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -9,6 +9,7 @@ import { ComboOverlay } from './ComboOverlay';
 import { SwipeFlash } from './SwipeFlash';
 import { PixelBurst } from './PixelBurst';
 import { TurboOverlay } from './TurboOverlay';
+import { FlockOverlay } from './FlockOverlay';
 import { SwipeHint } from './SwipeHint';
 import { RetroStart } from './RetroStart';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
@@ -78,6 +79,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const [showStart, setShowStart] = useState(false);
   const [combo, setCombo] = useState<number | null>(null);
   const [burstColor, setBurstColor] = useState<string | null>(null);
+  const [showFlock, setShowFlock] = useState(false);
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   const consecutiveDeleteRef = React.useRef(0);
@@ -186,13 +188,13 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
       setCombo(consecutiveDeleteRef.current);
     }
 
-    // Trigger confetti on long delete streaks
+    // Trigger confetti and bird flock on long delete streaks
     if (consecutiveDeleteRef.current >= STREAK_THRESHOLD) {
       setConfettiKey((k) => k + 1);
+      setShowFlock(true);
       consecutiveDeleteRef.current = 0;
       setCombo(null);
     }
-
 
     // Update current photo index for tracking progress
     setCurrentPhotoIndex((prev) => prev + 1);
@@ -444,6 +446,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
           origin={{ x: Dimensions.get('window').width / 2, y: 0 }}
         />
       )}
+
+      {showFlock && <FlockOverlay onDone={() => setShowFlock(false)} />}
 
       {combo && <ComboOverlay count={combo} onDone={() => setCombo(null)} />}
 


### PR DESCRIPTION
## Summary
- show birds flying across the screen when hitting a long delete streak
- document the new flock animation in the readme
- clarify mascot guidance to mention combo milestones

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68739e427598832ba0275f2043db3aa8