### PR TITLE
Add glitch overlay on delete streaks

### DIFF
--- a/components/GlitchOverlay.tsx
+++ b/components/GlitchOverlay.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withRepeat,
+  withSequence,
+  runOnJS,
+} from 'react-native-reanimated';
+
+interface GlitchOverlayProps {
+  onDone?: () => void;
+}
+
+export const GlitchOverlay: React.FC<GlitchOverlayProps> = ({ onDone }) => {
+  const offset = useSharedValue(0);
+  const scale = useSharedValue(1);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration: 60 });
+    offset.value = withRepeat(
+      withSequence(
+        withTiming(-4, { duration: 40 }),
+        withTiming(4, { duration: 40 })
+      ),
+      5,
+      true
+    );
+    scale.value = withRepeat(
+      withSequence(
+        withTiming(1.02, { duration: 60 }),
+        withTiming(1, { duration: 60 })
+      ),
+      5,
+      true
+    );
+
+    const timer = setTimeout(() => {
+      opacity.value = withTiming(0, { duration: 120 }, () => {
+        if (onDone) runOnJS(onDone)();
+      });
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [offset, scale, opacity, onDone]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateX: offset.value }, { scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[StyleSheet.absoluteFill, styles.overlay, style]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    backgroundColor: 'rgba(255,255,255,0.15)',
+  },
+});
+
+export default GlitchOverlay;

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -12,6 +12,7 @@ import { TurboOverlay } from './TurboOverlay';
 import { FlockOverlay } from './FlockOverlay';
 import { SwipeHint } from './SwipeHint';
 import { RetroStart } from './RetroStart';
+import { GlitchOverlay } from './GlitchOverlay';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
 import {
   fetchPhotoAssetsWithPagination,
@@ -80,10 +81,12 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const [combo, setCombo] = useState<number | null>(null);
   const [burstColor, setBurstColor] = useState<string | null>(null);
   const [showFlock, setShowFlock] = useState(false);
+  const [showGlitch, setShowGlitch] = useState(false);
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   const consecutiveDeleteRef = React.useRef(0);
   const STREAK_THRESHOLD = 10;
+  const GLITCH_STREAK = 5;
   const deckRef = React.useRef<SwipeDeckHandle>(null);
   const turboRef = React.useRef<NodeJS.Timeout | null>(null);
   const [turbo, setTurbo] = useState(false);
@@ -186,6 +189,10 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     consecutiveDeleteRef.current += 1;
     if (consecutiveDeleteRef.current >= 3) {
       setCombo(consecutiveDeleteRef.current);
+    }
+
+    if (consecutiveDeleteRef.current === GLITCH_STREAK) {
+      setShowGlitch(true);
     }
 
     // Trigger confetti and bird flock on long delete streaks
@@ -433,6 +440,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
       {swipeFlash && <SwipeFlash label={swipeFlash} onDone={() => setSwipeFlash(null)} />}
 
       {burstColor && <PixelBurst color={burstColor} onDone={() => setBurstColor(null)} />}
+
+      {showGlitch && <GlitchOverlay onDone={() => setShowGlitch(false)} />}
 
       {turbo && <TurboOverlay />}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ docs/
 ├── onboarding.md  # onboarding flow
 ├── ci.md          # CI setup
 ├── video.md       # handling video assets
-└── zen.md         # distraction-free play
+├── zen.md         # distraction-free play
+└── glitch.md      # short visual effect
 ```
 
 Each file is under three short paragraphs for quick reference.

--- a/docs/glitch.md
+++ b/docs/glitch.md
@@ -1,0 +1,6 @@
+# Glitch overlay
+
+A short glitch effect appears after five rapid deletes to keep the pace intense.
+It shifts the screen horizontally and scales slightly before fading away.
+The `GlitchOverlay` component handles the animation and runs only for a few
+hundred milliseconds so gameplay stays smooth.


### PR DESCRIPTION
## Summary
- show new `GlitchOverlay` after five fast deletes
- trigger glitch effect from PhotoGallery
- document glitch overlay

## Testing
- `npm install`
- `npm test`
- `npm run lint` *(fails: React hooks rule in FlockOverlay)*
- `npm run format` *(fails: React hooks rule in FlockOverlay)*

------
https://chatgpt.com/codex/tasks/task_e_6873a213a494832b9faf3ae5cbb7c0f1