### PR TITLE
Add fast-swipe speed line overlay

### DIFF
--- a/components/FlockOverlay.tsx
+++ b/components/FlockOverlay.tsx
@@ -32,31 +32,29 @@ export const FlockOverlay: React.FC<FlockOverlayProps> = ({ onDone }) => {
     );
   }, [progress, onDone]);
 
-  const birds = new Array(BIRD_COUNT).fill(0).map((_, i) => {
+  const Bird = ({ index }: { index: number }) => {
     const style = useAnimatedStyle(() => ({
       position: 'absolute',
-      bottom: i * 10,
+      bottom: index * 10,
       left: -30,
       transform: [
-        {
-          translateX: (progress.value - i * 0.1) * screenWidth,
-        },
-        {
-          translateY: Math.sin(progress.value * 6 + i) * 20,
-        },
+        { translateX: (progress.value - index * 0.1) * screenWidth },
+        { translateY: Math.sin(progress.value * 6 + index) * 20 },
       ],
       opacity: progress.value < 1 ? 1 : 0,
     }));
     return (
-      <Animated.Text key={i} style={[styles.bird, style]}>
+      <Animated.Text key={index} style={[styles.bird, style]}>
         🐦
       </Animated.Text>
     );
-  });
+  };
 
   return (
     <Animated.View pointerEvents="none" style={StyleSheet.absoluteFill}>
-      {birds}
+      {Array.from({ length: BIRD_COUNT }).map((_, i) => (
+        <Bird key={i} index={i} />
+      ))}
     </Animated.View>
   );
 };

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -14,6 +14,7 @@ import { SwipeHint } from './SwipeHint';
 import { RetroStart } from './RetroStart';
 import { GlitchOverlay } from './GlitchOverlay';
 import { WaveOverlay } from './WaveOverlay';
+import { SpeedLinesOverlay } from './SpeedLinesOverlay';
 import { BackgroundOptimizer } from './BackgroundOptimizer';
 import {
   fetchPhotoAssetsWithPagination,
@@ -84,6 +85,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const [showFlock, setShowFlock] = useState(false);
   const [showGlitch, setShowGlitch] = useState(false);
   const [showWave, setShowWave] = useState(false);
+  const [speedLinesDir, setSpeedLinesDir] = useState<'left' | 'right' | null>(
+    null
+  );
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   const consecutiveDeleteRef = React.useRef(0);
@@ -176,7 +180,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleSwipeLeft = async (item: SwipeDeckItem, index: number) => {
+  const handleSwipeLeft = async (
+    item: SwipeDeckItem,
+    index: number,
+    fast: boolean
+  ) => {
     // Swipe event - user wants to delete the current photo permanently
     const success = await deletePhotoAsset(item.id);
     if (!success) {
@@ -185,6 +193,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     }
     setSwipeFlash('DELETED!');
     setBurstColor('rgb(255,59,48)');
+    if (fast) setSpeedLinesDir('left');
     setShowSwipeHint(false);
     // Play a random voice clip for extra feedback
     audioService.playRandomVoice();
@@ -217,10 +226,15 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     // or a photo is permanently deleted from within the recycle bin screen.
   };
 
-  const handleSwipeRight = (item: SwipeDeckItem, index: number) => {
+  const handleSwipeRight = (
+    item: SwipeDeckItem,
+    index: number,
+    fast: boolean
+  ) => {
     // Swipe event - user keeps the current photo
     setSwipeFlash('KEPT!');
     setBurstColor('rgb(52,199,89)');
+    if (fast) setSpeedLinesDir('right');
     setShowSwipeHint(false);
 
     // Reset streak when a photo is kept
@@ -276,7 +290,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     tapTimesRef.current.push(now);
     if (tapTimesRef.current.length >= 5) {
       if (photos.length > 0) {
-        handleSwipeLeft(photos[0], 0);
+        handleSwipeLeft(photos[0], 0, false);
       }
       tapTimesRef.current = [];
     }
@@ -449,6 +463,13 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
       {burstColor && <PixelBurst color={burstColor} onDone={() => setBurstColor(null)} />}
 
       {showWave && <WaveOverlay onDone={() => setShowWave(false)} />}
+
+      {speedLinesDir && (
+        <SpeedLinesOverlay
+          direction={speedLinesDir}
+          onDone={() => setSpeedLinesDir(null)}
+        />
+      )}
 
       {showGlitch && <GlitchOverlay onDone={() => setShowGlitch(false)} />}
 

--- a/components/SpeedLinesOverlay.tsx
+++ b/components/SpeedLinesOverlay.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { Dimensions, StyleSheet, View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+
+interface SpeedLinesOverlayProps {
+  direction: 'left' | 'right';
+  onDone?: () => void;
+}
+
+const LINE_COUNT = 5;
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+export const SpeedLinesOverlay: React.FC<SpeedLinesOverlayProps> = ({
+  direction,
+  onDone,
+}) => {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withTiming(1, { duration: 250 }, () => {
+      if (onDone) runOnJS(onDone)();
+    });
+  }, [onDone, progress]);
+
+  const containerStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX:
+          (direction === 'left' ? -1 : 1) * progress.value * SCREEN_WIDTH,
+      },
+    ],
+    opacity: 1 - progress.value,
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[StyleSheet.absoluteFill, containerStyle]}
+    >
+      {Array.from({ length: LINE_COUNT }).map((_, i) => (
+        <View
+          key={i}
+          style={[
+            styles.line,
+            {
+              left: SCREEN_WIDTH / 2 + (i - LINE_COUNT / 2) * 12,
+            },
+          ]}
+        />
+      ))}
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  line: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: 2,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+  },
+});
+
+export default SpeedLinesOverlay;

--- a/components/SwipeCard.tsx
+++ b/components/SwipeCard.tsx
@@ -39,8 +39,8 @@ const HIT_SLOP = px(16);
 
 export interface SwipeCardProps {
   imageUri: string;
-  onSwipeLeft?: () => void;
-  onSwipeRight?: () => void;
+  onSwipeLeft?: (fast: boolean) => void;
+  onSwipeRight?: (fast: boolean) => void;
   style?: any;
   disabled?: boolean;
 }
@@ -99,6 +99,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       const velocityX = event.velocityX;
       const shouldSwipeLeft = translateX.value < -SWIPE_THRESHOLD || velocityX < -1000;
       const shouldSwipeRight = translateX.value > SWIPE_THRESHOLD || velocityX > 1000;
+      const fast = Math.abs(velocityX) > 2000;
 
       const velocityFactor = Math.min(Math.abs(velocityX) / 2000, 1);
       const exitDistance = px(screenWidth * (1.5 + velocityFactor));
@@ -121,7 +122,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
         // Play delete sound and trigger callback
         runOnJS(playDeleteSound)();
         if (onSwipeLeft) {
-          runOnJS(onSwipeLeft)();
+          runOnJS(onSwipeLeft)(fast);
         }
       } else if (shouldSwipeRight) {
         // Swipe right - keep
@@ -139,7 +140,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
         // Play keep sound and trigger callback
         runOnJS(playKeepSound)();
         if (onSwipeRight) {
-          runOnJS(onSwipeRight)();
+          runOnJS(onSwipeRight)(fast);
         }
       } else {
         // Snap back to center

--- a/components/SwipeDeck.tsx
+++ b/components/SwipeDeck.tsx
@@ -26,8 +26,8 @@ export interface SwipeDeckItem {
 
 export interface SwipeDeckProps {
   data: SwipeDeckItem[];
-  onSwipeLeft?: (item: SwipeDeckItem, index: number) => void;
-  onSwipeRight?: (item: SwipeDeckItem, index: number) => void;
+  onSwipeLeft?: (item: SwipeDeckItem, index: number, fast: boolean) => void;
+  onSwipeRight?: (item: SwipeDeckItem, index: number, fast: boolean) => void;
   onDeckEmpty?: () => void;
   maxVisibleCards?: number;
   cardSpacing?: number;
@@ -153,9 +153,9 @@ export const SwipeDeck = forwardRef<SwipeDeckHandle, SwipeDeckProps>(
     }, [data.length, onDeckEmpty]);
 
     const handleSwipeLeft = useCallback(
-      (item: SwipeDeckItem, index: number) => {
+      (item: SwipeDeckItem, index: number, fast: boolean) => {
         if (inputBlocked) return;
-        onSwipeLeft?.(item, index);
+        onSwipeLeft?.(item, index, fast);
 
         // Animate cards moving up in the stack
         for (let i = 0; i < Math.min(maxVisibleCards - 1, scaleValues.length); i++) {
@@ -178,9 +178,9 @@ export const SwipeDeck = forwardRef<SwipeDeckHandle, SwipeDeckProps>(
       ]
     );
     const handleSwipeRight = useCallback(
-      (item: SwipeDeckItem, index: number) => {
+      (item: SwipeDeckItem, index: number, fast: boolean) => {
         if (inputBlocked) return;
-        onSwipeRight?.(item, index);
+        onSwipeRight?.(item, index, fast);
 
         // Animate cards moving up in the stack
         for (let i = 0; i < Math.min(maxVisibleCards - 1, scaleValues.length); i++) {
@@ -236,13 +236,13 @@ export const SwipeDeck = forwardRef<SwipeDeckHandle, SwipeDeckProps>(
         swipeLeft: () => {
           const card = getVisibleCards()[0];
           if (card) {
-            handleSwipeLeft(card, card.dataIndex);
+            handleSwipeLeft(card, card.dataIndex, false);
           }
         },
         swipeRight: () => {
           const card = getVisibleCards()[0];
           if (card) {
-            handleSwipeRight(card, card.dataIndex);
+            handleSwipeRight(card, card.dataIndex, false);
           }
         },
       }),
@@ -287,8 +287,12 @@ export const SwipeDeck = forwardRef<SwipeDeckHandle, SwipeDeckProps>(
               ]}>
               <SwipeCard
                 imageUri={card.imageUri}
-                onSwipeLeft={() => handleSwipeLeft(card, card.dataIndex)}
-                onSwipeRight={() => handleSwipeRight(card, card.dataIndex)}
+                onSwipeLeft={(fast) =>
+                  handleSwipeLeft(card, card.dataIndex, fast)
+                }
+                onSwipeRight={(fast) =>
+                  handleSwipeRight(card, card.dataIndex, fast)
+                }
                 disabled={!isTopCard || inputBlocked}
                 style={{
                   shadowOpacity: isTopCard ? 0.3 : 0.1,

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ docs/
 ├── ci.md          # CI setup
 ├── video.md       # handling video assets
 ├── zen.md         # distraction-free play
-└── glitch.md      # short visual effect
+├── glitch.md      # short visual effect
+└── speedlines.md  # fast swipe overlay
 ```
 
 Each file is under three short paragraphs for quick reference.

--- a/docs/speedlines.md
+++ b/docs/speedlines.md
@@ -1,0 +1,3 @@
+Speed lines streak across the screen when a card is flung with high velocity. The overlay slides in from the swipe direction and fades within a quarter second so the action never slows.
+
+Implementation uses a short animated view of thin white bars. No additional state is tracked, keeping the effect lightweight.


### PR DESCRIPTION
## Summary
- add SpeedLinesOverlay effect
- trigger overlay when a card is swiped rapidly
- plumb fast-swipe info through SwipeCard and SwipeDeck
- keep hooks valid in FlockOverlay
- document the new overlay

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6873ac6a14c0832bbdf620525eb5cc62