### PR TITLE
Add shake-based turbo

### DIFF
--- a/__tests__/useShake.test.ts
+++ b/__tests__/useShake.test.ts
@@ -1,0 +1,31 @@
+jest.mock(
+  'expo-sensors',
+  () => ({
+    Accelerometer: {
+      addListener: jest.fn(() => ({ remove: jest.fn() })),
+      setUpdateInterval: jest.fn(),
+    },
+  }),
+  { virtual: true }
+);
+
+import { deltaMagnitude, isShake } from '../lib/useShake';
+
+test('deltaMagnitude computes distance', () => {
+  const a = { x: 0, y: 0, z: 0 };
+  const b = { x: 1, y: 2, z: 2 };
+  const dist = deltaMagnitude(a, b);
+  expect(dist).toBeCloseTo(3);
+});
+
+test('isShake detects movement above threshold', () => {
+  const a = { x: 0, y: 0, z: 0 };
+  const b = { x: 2, y: 2, z: 2 };
+  expect(isShake(a, b, 1.5)).toBe(true);
+});
+
+test('isShake ignores small movement', () => {
+  const a = { x: 0, y: 0, z: 0 };
+  const b = { x: 0.2, y: 0.2, z: 0.2 };
+  expect(isShake(a, b, 1)).toBe(false);
+});

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -37,6 +37,7 @@ import { px } from '~/lib/pixelPerfect';
 import { useRecycleBinStore } from '~/store/store';
 import { END_MESSAGES, createMessagePicker } from '~/lib/positiveMessages';
 import { audioService } from '~/lib/audioService';
+import { useShake } from '~/lib/useShake';
 
 const pickEndMessage = createMessagePicker(END_MESSAGES);
 
@@ -85,9 +86,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const [showFlock, setShowFlock] = useState(false);
   const [showGlitch, setShowGlitch] = useState(false);
   const [showWave, setShowWave] = useState(false);
-  const [speedLinesDir, setSpeedLinesDir] = useState<'left' | 'right' | null>(
-    null
-  );
+  const [speedLinesDir, setSpeedLinesDir] = useState<'left' | 'right' | null>(null);
   const startShownRef = React.useRef(false);
   const tapTimesRef = React.useRef<number[]>([]);
   const consecutiveDeleteRef = React.useRef(0);
@@ -180,11 +179,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleSwipeLeft = async (
-    item: SwipeDeckItem,
-    index: number,
-    fast: boolean
-  ) => {
+  const handleSwipeLeft = async (item: SwipeDeckItem, index: number, fast: boolean) => {
     // Swipe event - user wants to delete the current photo permanently
     const success = await deletePhotoAsset(item.id);
     if (!success) {
@@ -226,11 +221,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     // or a photo is permanently deleted from within the recycle bin screen.
   };
 
-  const handleSwipeRight = (
-    item: SwipeDeckItem,
-    index: number,
-    fast: boolean
-  ) => {
+  const handleSwipeRight = (item: SwipeDeckItem, index: number, fast: boolean) => {
     // Swipe event - user keeps the current photo
     setSwipeFlash('KEPT!');
     setBurstColor('rgb(52,199,89)');
@@ -412,6 +403,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     setTurbo(false);
   };
 
+  useShake(() => {
+    startTurbo();
+    setTimeout(stopTurbo, 1500);
+  });
+
   if (loading) {
     return (
       <View className={cn('flex-1 items-center justify-center', className)}>
@@ -465,10 +461,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
       {showWave && <WaveOverlay onDone={() => setShowWave(false)} />}
 
       {speedLinesDir && (
-        <SpeedLinesOverlay
-          direction={speedLinesDir}
-          onDone={() => setSpeedLinesDir(null)}
-        />
+        <SpeedLinesOverlay direction={speedLinesDir} onDone={() => setSpeedLinesDir(null)} />
       )}
 
       {showGlitch && <GlitchOverlay onDone={() => setShowGlitch(false)} />}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ docs/
 ├── zen.md         # distraction-free play
 ├── glitch.md      # short visual effect
 ├── tilt.md        # 3D card tilt effect
-└── speedlines.md  # fast swipe overlay
+├── speedlines.md  # fast swipe overlay
+└── shake.md       # shake-to-turbo mechanic
 ```
 
 Each file is under three short paragraphs for quick reference.

--- a/docs/shake.md
+++ b/docs/shake.md
@@ -1,0 +1,5 @@
+# Shake to Turbo
+
+Shake your phone to trigger a short burst of Turbo mode. The accelerometer listens for sudden movement and automatically swipes left for a couple seconds.
+
+The feature uses `useShake` from `lib/useShake.ts` to keep logic minimal. No extra state is tracked beyond a brief timer, so gameplay stays smooth.

--- a/lib/useShake.ts
+++ b/lib/useShake.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import { Accelerometer, AccelerometerMeasurement } from 'expo-sensors';
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Calculate the magnitude difference between two sensor samples.
+ */
+export function deltaMagnitude(a: Vec3, b: Vec3): number {
+  'worklet';
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Determine whether the difference indicates a shake.
+ */
+export function isShake(a: Vec3, b: Vec3, threshold = 1.4): boolean {
+  return deltaMagnitude(a, b) > threshold;
+}
+
+/**
+ * React hook that calls `onShake` when the device is shaken.
+ * Keeps logic lightweight by comparing successive accelerometer samples.
+ */
+export function useShake(onShake: () => void, threshold = 1.4) {
+  const last = useRef<AccelerometerMeasurement | null>(null);
+  const lastTime = useRef(0);
+
+  useEffect(() => {
+    Accelerometer.setUpdateInterval(100);
+    const sub = Accelerometer.addListener((data) => {
+      const previous = last.current;
+      if (previous && isShake(previous, data, threshold)) {
+        const now = Date.now();
+        if (now - lastTime.current > 500) {
+          lastTime.current = now;
+          onShake();
+        }
+      }
+      last.current = data;
+    });
+    return () => {
+      sub.remove();
+    };
+  }, [onShake, threshold]);
+}


### PR DESCRIPTION
## Summary
- introduce `useShake` hook to detect device shakes
- auto-activate Turbo mode with a quick shake gesture
- document the feature
- test the shake detection logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873febae250832b9a16937b53b8186e