### PR TITLE
Fix build errors and add expo-sensors

### DIFF
--- a/components/SwipeTrail.tsx
+++ b/components/SwipeTrail.tsx
@@ -136,22 +136,26 @@ export const SwipeTrail: React.FC<SwipeTrailProps> = ({
 
   return (
     <>
+      {/* pointerEvents isn't typed for Animated.Image but works at runtime */}
       <Animated.Image
         source={{ uri: imageUri }}
         style={style3}
         resizeMode="cover"
+        // @ts-expect-error pointerEvents not in ImageProps
         pointerEvents="none"
       />
       <Animated.Image
         source={{ uri: imageUri }}
         style={style2}
         resizeMode="cover"
+        // @ts-expect-error pointerEvents not in ImageProps
         pointerEvents="none"
       />
       <Animated.Image
         source={{ uri: imageUri }}
         style={style1}
         resizeMode="cover"
+        // @ts-expect-error pointerEvents not in ImageProps
         pointerEvents="none"
       />
     </>

--- a/lib/useShake.ts
+++ b/lib/useShake.ts
@@ -35,7 +35,7 @@ export function useShake(onShake: () => void, threshold = 1.4) {
 
   useEffect(() => {
     Accelerometer.setUpdateInterval(100);
-    const sub = Accelerometer.addListener((data) => {
+    const sub = Accelerometer.addListener((data: AccelerometerMeasurement) => {
       const previous = last.current;
       if (previous && isShake(previous, data, threshold)) {
         const now = Date.now();

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "expo-media-library": "^17.1.6",
         "expo-navigation-bar": "~4.2.4",
         "expo-router": "~5.0.3",
+        "expo-sensors": "~14.1.4",
         "expo-status-bar": "~2.2.3",
         "expo-store-review": "~8.1.5",
         "expo-system-ui": "~5.0.6",
@@ -11289,6 +11290,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-sensors": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-sensors/-/expo-sensors-14.1.4.tgz",
+      "integrity": "sha512-KHROi5C8dhXedMwx7fZ5eyv9p382F5XOIex4a+GpdOTL3OY4xyk08kt7x64FtMeeoT87gYD3mb9LrBpHyNubkg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expo-media-library": "^17.1.6",
     "expo-navigation-bar": "~4.2.4",
     "expo-router": "~5.0.3",
+    "expo-sensors": "~14.1.4",
     "expo-status-bar": "~2.2.3",
     "expo-store-review": "~8.1.5",
     "expo-system-ui": "~5.0.6",


### PR DESCRIPTION
## Summary
- add expo-sensors dependency
- fix types in useShake hook
- allow pointerEvents prop on SwipeTrail images

## Testing
- `npm test`
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6874056f4bc4832bba6d65073575a4cf