### PR TITLE
Add navigation mode toggle and clarify deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A minimal photo clean-up game for Android built with Expo React Native. A small 
 You can also move a photo into any album using the folder button.
 A new WhatsApp tab lets you review images from the WhatsApp Images album.
 
+Photos deleted in the main gallery or recycle bin are removed from the device
+immediately. There is no separate trash folder beyond the in-app recycle bin,
+so use caution when swiping!
+
 Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
 
 See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, and CI.

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { useRecycleBinStore } from '~/store/store';
 import { AudioToggle } from '~/components/AudioToggle';
 import { ZenToggle } from '~/components/ZenToggle';
+import { NavigationToggle } from '~/components/NavigationToggle';
 
 function RecycleBinTabIcon({ color, size }: { color: string; size: number }) {
   const { deletedPhotos } = useRecycleBinStore();
@@ -26,6 +27,7 @@ export default function TabLayout() {
         headerTitle: '',
         headerRight: () => (
           <View className="mr-1 flex-row items-center gap-2">
+            <NavigationToggle />
             <ZenToggle />
             <AudioToggle />
           </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,8 +30,13 @@ export default function RootLayout() {
   useInitialAndroidBarSync();
   const { colorScheme, isDarkColorScheme } = useColorScheme();
   const fontsLoaded = useCustomFonts();
-  const { loadDeletedPhotos, loadTotalDeleted, checkOnboardingStatus, loadZenMode } =
-    useRecycleBinStore();
+  const {
+    loadDeletedPhotos,
+    loadTotalDeleted,
+    checkOnboardingStatus,
+    loadZenMode,
+    loadNavigationMode,
+  } = useRecycleBinStore();
   const segments = useSegments();
   const router = useRouter();
 
@@ -40,7 +45,8 @@ export default function RootLayout() {
     loadDeletedPhotos();
     loadTotalDeleted();
     loadZenMode();
-  }, [loadDeletedPhotos, loadTotalDeleted, loadZenMode]);
+    loadNavigationMode();
+  }, [loadDeletedPhotos, loadTotalDeleted, loadZenMode, loadNavigationMode]);
 
   // Check onboarding status only once on startup to avoid
   // repeated AsyncStorage reads when navigating between screens

--- a/components/NavigationToggle.tsx
+++ b/components/NavigationToggle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRecycleBinStore } from '~/store/store';
+import { px } from '~/lib/pixelPerfect';
+
+export const NavigationToggle: React.FC = () => {
+  const { navigationMode, setNavigationMode } = useRecycleBinStore();
+
+  const toggle = () => {
+    setNavigationMode(!navigationMode);
+  };
+
+  return (
+    <Pressable onPress={toggle} className="p-1">
+      <Ionicons
+        name={navigationMode ? 'swap-horizontal' : 'trash'}
+        size={px(16)}
+        color="rgb(var(--android-primary))"
+      />
+    </Pressable>
+  );
+};
+
+export default NavigationToggle;

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -57,7 +57,12 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const { showActionSheetWithOptions } = useActionSheet();
 
   // Use RecycleBin store
-  const { resetGallery: resetRecycleBinStore, loadZenMode } = useRecycleBinStore();
+  const {
+    resetGallery: resetRecycleBinStore,
+    loadZenMode,
+    loadNavigationMode,
+    navigationMode,
+  } = useRecycleBinStore();
 
   useEffect(() => {
     return () => {
@@ -67,7 +72,8 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
 
   useEffect(() => {
     loadZenMode();
-  }, [loadZenMode]);
+    loadNavigationMode();
+  }, [loadZenMode, loadNavigationMode]);
 
   const [photos, setPhotos] = useState<SwipeDeckItem[]>([]);
   const [prefetchedPhotos, setPrefetchedPhotos] = useState<SwipeDeckItem[]>([]);
@@ -180,6 +186,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   }, []);
 
   const handleSwipeLeft = async (item: SwipeDeckItem, index: number, fast: boolean) => {
+    if (navigationMode) {
+      audioService.playTapSound();
+      setCurrentPhotoIndex((prev) => prev + 1);
+      return;
+    }
     // Swipe event - user wants to delete the current photo permanently
     const success = await deletePhotoAsset(item.id);
     if (!success) {
@@ -222,6 +233,11 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   };
 
   const handleSwipeRight = (item: SwipeDeckItem, index: number, fast: boolean) => {
+    if (navigationMode) {
+      audioService.playTapSound();
+      setCurrentPhotoIndex((prev) => prev + 1);
+      return;
+    }
     // Swipe event - user keeps the current photo
     setSwipeFlash('KEPT!');
     setBurstColor('rgb(52,199,89)');

--- a/store/store.ts
+++ b/store/store.ts
@@ -23,6 +23,7 @@ const ONBOARDING_STORAGE_KEY = '@decluttr_onboarding_completed';
 const DELETED_PHOTOS_STORAGE_KEY = '@decluttr_deleted_photos';
 const TOTAL_DELETED_STORAGE_KEY = '@decluttr_total_deleted';
 const ZEN_MODE_STORAGE_KEY = '@decluttr_zen_mode';
+const NAV_MODE_STORAGE_KEY = '@decluttr_navigation_mode';
 
 // RecycleBin types
 export interface DeletedPhoto {
@@ -37,6 +38,7 @@ export interface RecycleBinState {
   totalDeleted: number;
   onboardingCompleted: boolean;
   zenMode: boolean;
+  navigationMode: boolean;
   addDeletedPhoto: (photo: DeletedPhoto) => void;
   restorePhoto: (photoId: string) => DeletedPhoto | null;
   permanentlyDelete: (photoId: string) => Promise<boolean>;
@@ -57,6 +59,8 @@ export interface RecycleBinState {
   resetOnboarding: () => Promise<void>;
   loadZenMode: () => Promise<void>;
   setZenMode: (enabled: boolean) => Promise<void>;
+  loadNavigationMode: () => Promise<void>;
+  setNavigationMode: (enabled: boolean) => Promise<void>;
 }
 
 export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
@@ -64,6 +68,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   totalDeleted: 0,
   onboardingCompleted: false,
   zenMode: false,
+  navigationMode: false,
 
   // Helper to persist deleted photos
   saveDeletedPhotos: async (photos: DeletedPhoto[]) => {
@@ -115,6 +120,28 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
     } catch (error) {
       console.error('Failed to save zen mode:', error);
       set({ zenMode: enabled });
+    }
+  },
+
+  loadNavigationMode: async () => {
+    try {
+      const storage = getAsyncStorage();
+      const stored = await storage.getItem(NAV_MODE_STORAGE_KEY);
+      set({ navigationMode: stored === 'true' });
+    } catch (error) {
+      console.error('Failed to load navigation mode:', error);
+      set({ navigationMode: false });
+    }
+  },
+
+  setNavigationMode: async (enabled: boolean) => {
+    try {
+      const storage = getAsyncStorage();
+      await storage.setItem(NAV_MODE_STORAGE_KEY, String(enabled));
+      set({ navigationMode: enabled });
+    } catch (error) {
+      console.error('Failed to save navigation mode:', error);
+      set({ navigationMode: enabled });
     }
   },
 


### PR DESCRIPTION
## Summary
- clarify that deletions are permanent in README
- load navigation mode setting on app startup
- add toggle to switch swipe behaviour in tab header
- persist navigationMode in store
- support navigation swipes in PhotoGallery when enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740a082520832b8876a43d24e3c97d