### PR TITLE
Implement navigation default and album bulk delete

### DIFF
--- a/app/album/[name].tsx
+++ b/app/album/[name].tsx
@@ -1,13 +1,42 @@
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { Container } from '~/components/Container';
 import { PhotoGallery } from '~/components/PhotoGallery';
+import { TouchableOpacity, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { deleteAllAssetsFromAlbum } from '~/lib/mediaLibrary';
 
 export default function AlbumGallery() {
   const { name } = useLocalSearchParams<{ name: string }>();
   const albumName = Array.isArray(name) ? name[0] : name;
+  const handleDeleteAll = () => {
+    Alert.alert('Delete All', `Remove all items in ${albumName}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          const success = await deleteAllAssetsFromAlbum(albumName);
+          if (success) {
+            Alert.alert('Deleted', 'Album cleared.');
+          } else {
+            Alert.alert('Error', 'Failed to delete album.');
+          }
+        },
+      },
+    ]);
+  };
   return (
     <>
-      <Stack.Screen options={{ title: albumName }} />
+      <Stack.Screen
+        options={{
+          title: albumName,
+          headerRight: () => (
+            <TouchableOpacity onPress={handleDeleteAll} className="mr-2">
+              <Ionicons name="trash" size={20} color="rgb(255,82,82)" />
+            </TouchableOpacity>
+          ),
+        }}
+      />
       <Container>
         <PhotoGallery albumName={albumName} />
       </Container>

--- a/store/store.ts
+++ b/store/store.ts
@@ -68,7 +68,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   totalDeleted: 0,
   onboardingCompleted: false,
   zenMode: false,
-  navigationMode: false,
+  navigationMode: true,
 
   // Helper to persist deleted photos
   saveDeletedPhotos: async (photos: DeletedPhoto[]) => {
@@ -127,10 +127,10 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
     try {
       const storage = getAsyncStorage();
       const stored = await storage.getItem(NAV_MODE_STORAGE_KEY);
-      set({ navigationMode: stored === 'true' });
+      set({ navigationMode: stored !== null ? stored === 'true' : true });
     } catch (error) {
       console.error('Failed to load navigation mode:', error);
-      set({ navigationMode: false });
+      set({ navigationMode: true });
     }
   },
 


### PR DESCRIPTION
## Summary
- default to navigation-mode swipes
- allow clearing all photos in an album
- support deleting assets from a whole album
- test album deletion logic

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68740ce24528832baf602d846178efa7