### PR TITLE
Add multi-select delete

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -35,6 +35,7 @@ describe('RecycleBin store', () => {
       onboardingCompleted: false,
       zenMode: false,
     });
+    jest.clearAllMocks();
   });
 
   it('adds and restores photos', async () => {
@@ -59,6 +60,16 @@ describe('RecycleBin store', () => {
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(1);
     await expect(clearRecycleBin()).resolves.toBe(true);
     expect(mediaLibrary.deletePhotoAssets).toHaveBeenCalledWith(['2']);
+    expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
+  });
+
+  it('permanently deletes multiple photos', async () => {
+    const { addDeletedPhoto, permanentlyDeleteMany } = useRecycleBinStore.getState();
+    addDeletedPhoto(createPhoto('a'));
+    addDeletedPhoto(createPhoto('b'));
+    await expect(permanentlyDeleteMany(['a', 'b'])).resolves.toBe(true);
+    const calls = (mediaLibrary.deletePhotoAssets as jest.Mock).mock.calls;
+    expect(new Set(calls[calls.length - 1][0])).toEqual(new Set(['a', 'b']));
     expect(useRecycleBinStore.getState().deletedPhotos).toHaveLength(0);
   });
 

--- a/app/(tabs)/months.tsx
+++ b/app/(tabs)/months.tsx
@@ -5,14 +5,22 @@ import { Container } from '~/components/Container';
 import { Text } from '~/components/nativewindui/Text';
 import { deleteAssetsFromMonth } from '~/lib/mediaLibrary';
 
-interface Month { year: number; month: number; label: string; }
+interface Month {
+  year: number;
+  month: number;
+  label: string;
+}
 
 const generateMonths = (count: number = 12): Month[] => {
   const months: Month[] = [];
   const now = new Date();
   for (let i = 0; i < count; i++) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    months.push({ year: d.getFullYear(), month: d.getMonth() + 1, label: d.toLocaleString('default', { month: 'long', year: 'numeric' }) });
+    months.push({
+      year: d.getFullYear(),
+      month: d.getMonth() + 1,
+      label: d.toLocaleString('default', { month: 'long', year: 'numeric' }),
+    });
   }
   return months;
 };
@@ -31,7 +39,10 @@ export default function Months() {
           setBusy(true);
           const success = await deleteAssetsFromMonth(m.year, m.month);
           setBusy(false);
-          Alert.alert(success ? 'Deleted' : 'Error', success ? 'Month cleared.' : 'Failed to delete');
+          Alert.alert(
+            success ? 'Deleted' : 'Error',
+            success ? 'Month cleared.' : 'Failed to delete'
+          );
         },
       },
     ]);
@@ -47,8 +58,7 @@ export default function Months() {
               key={`${m.year}-${m.month}`}
               onPress={() => handleDelete(m)}
               disabled={busy}
-              className="mb-4 rounded-md border border-border p-4"
-            >
+              className="mb-4 rounded-md border border-border p-4">
               <Text>{m.label}</Text>
             </TouchableOpacity>
           ))}


### PR DESCRIPTION
## Summary
- format months list screen
- support multi-select actions in the recycle bin
- expose bulk delete helpers in zustand store
- test new permanentlyDeleteMany helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687414156df0832b81b8039b0f1d0db4