### PR TITLE
Fix expo gradle configs

### DIFF
--- a/patches/expo+53.0.9.patch
+++ b/patches/expo+53.0.9.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/expo/android/build.gradle b/node_modules/expo/android/build.gradle
+index acc4dac..ebed21e 100644
+--- a/node_modules/expo/android/build.gradle
++++ b/node_modules/expo/android/build.gradle
+@@ -40,11 +40,14 @@ expoModule {
+ }
+ 
+ android {
++  compileSdkVersion rootProject.extra.safeGet('compileSdkVersion') ?: 35
+   namespace "expo.core"
+   defaultConfig {
+     versionCode 1
+     versionName "53.0.9"
+     consumerProguardFiles("proguard-rules.pro")
++    minSdkVersion rootProject.extra.safeGet('minSdkVersion') ?: 24
++    targetSdkVersion rootProject.extra.safeGet('targetSdkVersion') ?: 35
+   }
+   testOptions {
+     unitTests.includeAndroidResources = true

--- a/patches/expo-font+11.10.3.patch
+++ b/patches/expo-font+11.10.3.patch
@@ -1,0 +1,46 @@
+diff --git a/node_modules/expo-font/android/build.gradle b/node_modules/expo-font/android/build.gradle
+index 7de989e..5b9c2bc 100644
+--- a/node_modules/expo-font/android/build.gradle
++++ b/node_modules/expo-font/android/build.gradle
+@@ -43,17 +43,17 @@ buildscript {
+ // Remove this if and it's contents, when support for SDK49 is dropped
+ if (!safeExtGet("expoProvidesDefaultConfig", false)) {
+   afterEvaluate {
+-    publishing {
+-      publications {
+-        release(MavenPublication) {
+-          from components.release
++      publishing {
++        publications {
++          release(MavenPublication) {
++            from components["release"]
++          }
+         }
+-      }
+-      repositories {
+-        maven {
+-          url = mavenLocal().url
++        repositories {
++          maven {
++            url = mavenLocal().url
++          }
+         }
+-      }
+     }
+   }
+ }
+@@ -61,11 +61,11 @@ if (!safeExtGet("expoProvidesDefaultConfig", false)) {
+ android {
+   // Remove this if and it's contents, when support for SDK49 is dropped
+   if (!safeExtGet("expoProvidesDefaultConfig", false)) {
+-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
++      compileSdkVersion safeExtGet("compileSdkVersion", 35)
+ 
+     defaultConfig {
+-      minSdkVersion safeExtGet("minSdkVersion", 23)
+-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
++        minSdkVersion safeExtGet("minSdkVersion", 24)
++        targetSdkVersion safeExtGet("targetSdkVersion", 35)
+     }
+ 
+     publishing {

--- a/patches/expo-modules-autolinking+2.1.10.patch
+++ b/patches/expo-modules-autolinking+2.1.10.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/build.gradle.kts b/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/build.gradle.kts
+index 1b7048a..3aca925 100644
+--- a/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/build.gradle.kts
++++ b/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/build.gradle.kts
+@@ -29,7 +29,7 @@ tasks.withType<KotlinCompile> {
+ }
+ 
+ group = "expo.modules"
+-version "1.0"
++version = "1.0"
+ 
+ tasks.withType<Test>().configureEach {
+   testLogging {
+diff --git a/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt b/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+index 5b8457a..c5a768c 100644
+--- a/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
++++ b/node_modules/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+@@ -26,8 +26,8 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
+     project.logger.quiet("")
+     project.logger.quiet("Using expo modules")
+ 
+-    val (prebuiltProjects, projects) = config.allProjects.partition { project ->
+-      project.usePublication
++    val (prebuiltProjects, projects) = config.allProjects.partition { pkg ->
++      pkg.usePublication
+     }
+ 
+     project.withSubprojects(projects) { subproject ->

--- a/patches/expo-modules-core+2.3.13.patch
+++ b/patches/expo-modules-core+2.3.13.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+index 9bfae8d..69c35d0 100644
+--- a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
++++ b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+@@ -6,8 +6,9 @@ internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int, tar
+   this.compileSdk = compileSdk
+   defaultConfig {
+     this@defaultConfig.minSdk = minSdk
+-    this@defaultConfig.targetSdk = targetSdk
+   }
++  testOptions.targetSdk = targetSdk
++  lint.targetSdk = targetSdk
+ }
+ 
+ internal fun LibraryExtension.applyLinterOptions() {


### PR DESCRIPTION
## Summary
- patch expo modules to compile with AGP 8
- set compileSdk and targetSdk on core modules
- fix autolinking plugin warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68744394e6f0832ba3c66fc2fd788408