### PR TITLE
Fix linter warnings and remove unused Zustand store

### DIFF
--- a/app/(tabs)/months.tsx
+++ b/app/(tabs)/months.tsx
@@ -1,6 +1,6 @@
 import { Stack } from 'expo-router';
 import { useState } from 'react';
-import { View, Alert, TouchableOpacity, ScrollView } from 'react-native';
+import { Alert, TouchableOpacity, ScrollView } from 'react-native';
 import { Container } from '~/components/Container';
 import { Text } from '~/components/nativewindui/Text';
 import { deleteAssetsFromMonth } from '~/lib/mediaLibrary';

--- a/components/FlockOverlay.tsx
+++ b/components/FlockOverlay.tsx
@@ -8,7 +8,6 @@ import Animated, {
   withDelay,
   Easing,
 } from 'react-native-reanimated';
-import { Text } from '~/components/nativewindui/Text';
 
 interface FlockOverlayProps {
   onDone?: () => void;

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,19 +1,6 @@
 import { create } from 'zustand';
 import { getAsyncStorage } from '~/lib/asyncStorageWrapper';
 import { deletePhotoAsset, deletePhotoAssets } from '~/lib/mediaLibrary';
-export interface BearState {
-  bears: number;
-  increasePopulation: () => void;
-  removeAllBears: () => void;
-  updateBears: (newBears: number) => void;
-}
-
-export const useStore = create<BearState>((set) => ({
-  bears: 0,
-  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
-  removeAllBears: () => set({ bears: 0 }),
-  updateBears: (newBears) => set({ bears: newBears }),
-}));
 
 // XP Constants
 // XP system removed for a leaner gameplay loop


### PR DESCRIPTION
## Summary
- remove unused `View` and `Text` imports
- delete dead Zustand store example

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687448c498ac832bb55a1c3e2c339cbf