### PR TITLE
Fix Gradle build by using safeExtGet

### DIFF
--- a/patches/expo+53.0.9.patch
+++ b/patches/expo+53.0.9.patch
@@ -2,18 +2,22 @@ diff --git a/node_modules/expo/android/build.gradle b/node_modules/expo/android/
 index acc4dac..ebed21e 100644
 --- a/node_modules/expo/android/build.gradle
 +++ b/node_modules/expo/android/build.gradle
-@@ -40,11 +40,14 @@ expoModule {
+@@ -40,11 +40,11 @@ expoModule {
  }
  
  android {
-+  compileSdkVersion rootProject.extra.safeGet('compileSdkVersion') ?: 35
+-  compileSdkVersion rootProject.extra.safeGet('compileSdkVersion') ?: 35
++  compileSdkVersion safeExtGet('compileSdkVersion', 35)
    namespace "expo.core"
    defaultConfig {
      versionCode 1
      versionName "53.0.9"
      consumerProguardFiles("proguard-rules.pro")
-+    minSdkVersion rootProject.extra.safeGet('minSdkVersion') ?: 24
-+    targetSdkVersion rootProject.extra.safeGet('targetSdkVersion') ?: 35
+-    minSdkVersion rootProject.extra.safeGet('minSdkVersion') ?: 24
+-    targetSdkVersion rootProject.extra.safeGet('targetSdkVersion') ?: 35
++    minSdkVersion safeExtGet('minSdkVersion', 24)
++    targetSdkVersion safeExtGet('targetSdkVersion', 35)
    }
    testOptions {
      unitTests.includeAndroidResources = true
+   }


### PR DESCRIPTION
## Summary
- fix patch for expo android build script to use `safeExtGet`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874a3bcc78c832b8913b00ccb6d59b3