### PR TITLE
Fix compileSdk setup for expo modules

### DIFF
--- a/patches/expo-font+11.10.3.patch
+++ b/patches/expo-font+11.10.3.patch
@@ -1,8 +1,16 @@
 diff --git a/node_modules/expo-font/android/build.gradle b/node_modules/expo-font/android/build.gradle
-index 7de989e..5b9c2bc 100644
+index 7de989e..3636e01 100644
 --- a/node_modules/expo-font/android/build.gradle
 +++ b/node_modules/expo-font/android/build.gradle
-@@ -43,17 +43,17 @@ buildscript {
+@@ -9,6 +9,7 @@ def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.ab
+ if (expoModulesCorePlugin.exists()) {
+   apply from: expoModulesCorePlugin
+   applyKotlinExpoModulesCorePlugin()
++  useDefaultAndroidSdkVersions()
+   // Remove this check, but keep the contents after SDK49 support is dropped
+   if (safeExtGet("expoProvidesDefaultConfig", false)) {
+     useExpoPublishing()
+@@ -43,17 +44,17 @@ buildscript {
  // Remove this if and it's contents, when support for SDK49 is dropped
  if (!safeExtGet("expoProvidesDefaultConfig", false)) {
    afterEvaluate {
@@ -29,7 +37,7 @@ index 7de989e..5b9c2bc 100644
      }
    }
  }
-@@ -61,11 +61,11 @@ if (!safeExtGet("expoProvidesDefaultConfig", false)) {
+@@ -61,11 +62,11 @@ if (!safeExtGet("expoProvidesDefaultConfig", false)) {
  android {
    // Remove this if and it's contents, when support for SDK49 is dropped
    if (!safeExtGet("expoProvidesDefaultConfig", false)) {

--- a/patches/expo-haptics+12.8.1.patch
+++ b/patches/expo-haptics+12.8.1.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/expo-haptics/android/build.gradle b/node_modules/expo-haptics/android/build.gradle
+index 69db12c..96b36aa 100644
+--- a/node_modules/expo-haptics/android/build.gradle
++++ b/node_modules/expo-haptics/android/build.gradle
+@@ -9,6 +9,7 @@ def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.ab
+ if (expoModulesCorePlugin.exists()) {
+   apply from: expoModulesCorePlugin
+   applyKotlinExpoModulesCorePlugin()
++  useDefaultAndroidSdkVersions()
+   // Remove this check, but keep the contents after SDK49 support is dropped
+   if (safeExtGet("expoProvidesDefaultConfig", false)) {
+     useExpoPublishing()


### PR DESCRIPTION
## Summary
- ensure expo-font & expo-haptics android builds use default sdk versions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874ba53153c832b8729faed081d8df4