### PR TITLE
Add permanent delete warning

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -14,7 +14,7 @@ import { px } from '~/lib/pixelPerfect';
 const screens = [
   {
     title: 'Declutter Photos',
-    subtitle: 'Swipe left to delete, right to keep.',
+    subtitle: 'Swipe left to delete forever, right to keep.',
     image: <View style={{ height: px(180) }} />,
     backgroundColor: '#025CBD',
   },

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -64,6 +64,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     loadZenMode,
     loadNavigationMode,
     navigationMode,
+    loadDeleteWarningShown,
+    setDeleteWarningShown,
+    deleteWarningShown,
   } = useRecycleBinStore();
 
   useEffect(() => {
@@ -75,7 +78,23 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   useEffect(() => {
     loadZenMode();
     loadNavigationMode();
-  }, [loadZenMode, loadNavigationMode]);
+    loadDeleteWarningShown();
+  }, [loadZenMode, loadNavigationMode, loadDeleteWarningShown]);
+
+  useEffect(() => {
+    if (deleteWarningShown === false) {
+      Alert.alert(
+        'Permanent Deletion',
+        'Swiping left removes photos from your device immediately. There is no system trash.',
+        [
+          {
+            text: 'Got it',
+            onPress: () => setDeleteWarningShown(true),
+          },
+        ]
+      );
+    }
+  }, [deleteWarningShown, setDeleteWarningShown]);
 
   const [photos, setPhotos] = useState<SwipeDeckItem[]>([]);
   const [prefetchedPhotos, setPrefetchedPhotos] = useState<SwipeDeckItem[]>([]);

--- a/store/store.ts
+++ b/store/store.ts
@@ -11,6 +11,7 @@ const DELETED_PHOTOS_STORAGE_KEY = '@decluttr_deleted_photos';
 const TOTAL_DELETED_STORAGE_KEY = '@decluttr_total_deleted';
 const ZEN_MODE_STORAGE_KEY = '@decluttr_zen_mode';
 const NAV_MODE_STORAGE_KEY = '@decluttr_navigation_mode';
+const DELETE_WARNING_KEY = '@decluttr_delete_warning_shown';
 
 // RecycleBin types
 export interface DeletedPhoto {
@@ -26,6 +27,7 @@ export interface RecycleBinState {
   onboardingCompleted: boolean;
   zenMode: boolean;
   navigationMode: boolean;
+  deleteWarningShown: boolean;
   addDeletedPhoto: (photo: DeletedPhoto) => void;
   restorePhoto: (photoId: string) => DeletedPhoto | null;
   permanentlyDelete: (photoId: string) => Promise<boolean>;
@@ -50,6 +52,8 @@ export interface RecycleBinState {
   setZenMode: (enabled: boolean) => Promise<void>;
   loadNavigationMode: () => Promise<void>;
   setNavigationMode: (enabled: boolean) => Promise<void>;
+  loadDeleteWarningShown: () => Promise<void>;
+  setDeleteWarningShown: (shown: boolean) => Promise<void>;
 }
 
 export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
@@ -58,6 +62,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   onboardingCompleted: false,
   zenMode: false,
   navigationMode: true,
+  deleteWarningShown: true,
 
   // Helper to persist deleted photos
   saveDeletedPhotos: async (photos: DeletedPhoto[]) => {
@@ -131,6 +136,28 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
     } catch (error) {
       console.error('Failed to save navigation mode:', error);
       set({ navigationMode: enabled });
+    }
+  },
+
+  loadDeleteWarningShown: async () => {
+    try {
+      const storage = getAsyncStorage();
+      const stored = await storage.getItem(DELETE_WARNING_KEY);
+      set({ deleteWarningShown: stored === 'true' });
+    } catch (error) {
+      console.error('Failed to load delete warning flag:', error);
+      set({ deleteWarningShown: true });
+    }
+  },
+
+  setDeleteWarningShown: async (shown: boolean) => {
+    try {
+      const storage = getAsyncStorage();
+      await storage.setItem(DELETE_WARNING_KEY, String(shown));
+      set({ deleteWarningShown: shown });
+    } catch (error) {
+      console.error('Failed to save delete warning flag:', error);
+      set({ deleteWarningShown: shown });
     }
   },
 


### PR DESCRIPTION
## Summary
- warn first-time users that photo deletions are permanent
- persist acknowledgement in AsyncStorage via RecycleBin store
- mention permanence in onboarding slide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874dd5ee770832b9e7b2d6bd23068da