### PR TITLE
Improve emulator troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Photos deleted in the main gallery or recycle bin are removed from the device
 immediately. There is no separate trash folder beyond the in-app recycle bin,
 so use caution when swiping!
 
-Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `expo run:android` or `eas build`.
+Run `npm install` then `npm start` to launch the app. For full media-library access you need a development build via `npx expo run:android` or `eas build`. The legacy global `expo` CLI can fail on Node 17 and above.
 
 See `docs/README.md` for an outline of the documentation including guides on audio, the mascot, onboarding, and CI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ docs/
 ├── mascot.md      # mascot assets
 ├── onboarding.md  # onboarding flow
 ├── ci.md          # CI setup
+├── android.md     # emulator troubleshooting
 ├── video.md       # handling video assets
 ├── zen.md         # distraction-free play
 ├── glitch.md      # short visual effect

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,0 +1,5 @@
+# Android emulator setup
+
+Use `npx expo run:android` to build and launch the development client. The old global `expo` package fails on Node 17+.
+
+If you see `spawn emulator ENOENT`, install Android Studio and create a virtual device. Ensure the `emulator` command is in your `PATH` or set `ANDROID_HOME` to the SDK location.


### PR DESCRIPTION
## Summary
- document how to use the new Expo CLI with Node 17+
- outline common `spawn emulator ENOENT` fixes
- list new doc in the docs overview

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875e2d539c4832b90705e7a33deb7ca