### PR TITLE
Improve shake turbo behavior

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,4 +17,4 @@
 - Share images without captions or as documents.
 - Compress or resize photos and offer basic editing tools.
 - AI-based sorting into categories like selfies or pets.
-\n- [ ] Optimize memory usage when analyzing large photo libraries
+- [ ] Optimize memory usage when analyzing large photo libraries

--- a/__tests__/mediaLibrary.test.ts
+++ b/__tests__/mediaLibrary.test.ts
@@ -28,72 +28,84 @@ jest.mock('expo-media-library', () => {
       assets: Array.from({ length: first }, (_, i) => ({ id: `id0${i}`, uri: `uri0${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'cursor0',
+      totalCount: first,
     }))
     // fetchPhotoAssetsWithPagination test
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `id1${i}`, uri: `uri1${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'cursor1',
+      totalCount: first,
     }))
     // fetchAllPhotoAssets first page
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `id2${i}`, uri: `uri2${i}` })),
       hasNextPage: true,
       endCursor: after ? `${after}-end` : 'cursor2',
+      totalCount: first * 2,
     }))
     // fetchAllPhotoAssets second page
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `id3${i}`, uri: `uri3${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'cursor3',
+      totalCount: first * 2,
     }))
     // fetchVideoAssetsWithPagination
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `vid${i}`, uri: `vuri${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'vcursor0',
+      totalCount: first,
     }))
     // fetchAllVideoAssets first page
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `vidA${i}`, uri: `vuriA${i}` })),
       hasNextPage: true,
       endCursor: after ? `${after}-end` : 'vcursor1',
+      totalCount: first * 2,
     }))
     // fetchAllVideoAssets second page
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `vidB${i}`, uri: `vuriB${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'vcursor2',
+      totalCount: first * 2,
     }))
     // fetchAssetsFromAlbumWithPagination
     .mockImplementationOnce(({ after, first }) => ({
       assets: Array.from({ length: first }, (_, i) => ({ id: `wa${i}`, uri: `wauri${i}` })),
       hasNextPage: false,
       endCursor: after ? `${after}-end` : 'wa-end',
+      totalCount: first,
     }))
     // deleteAllAssetsFromAlbum first page
     .mockImplementationOnce(() => ({
       assets: [{ id: 'del1', uri: 'deluri1' }],
       hasNextPage: true,
       endCursor: 'del-c1',
+      totalCount: 2,
     }))
     // deleteAllAssetsFromAlbum second page
     .mockImplementationOnce(() => ({
       assets: [{ id: 'del2', uri: 'deluri2' }],
       hasNextPage: false,
       endCursor: 'del-c2',
+      totalCount: 2,
     }))
     // deleteAssetsFromMonth first page
     .mockImplementationOnce(() => ({
       assets: [{ id: 'm1', uri: 'muri1' }],
       hasNextPage: true,
       endCursor: 'm-c1',
+      totalCount: 2,
     }))
     // deleteAssetsFromMonth second page
     .mockImplementationOnce(() => ({
       assets: [{ id: 'm2', uri: 'muri2' }],
       hasNextPage: false,
       endCursor: 'm-c2',
+      totalCount: 2,
     }));
 
   const getAlbumAsync = jest.fn().mockResolvedValue({ id: 'wa1', title: 'WhatsApp Images' });
@@ -140,6 +152,7 @@ describe('mediaLibrary', () => {
     const result = await fetchPhotoAssetsWithPagination('start', 1);
     expect(result.assets).toHaveLength(1);
     expect(result.endCursor).toBe('start-end');
+    expect(result.totalCount).toBe(1);
   });
 
   it('fetches all photo assets across pages', async () => {
@@ -153,6 +166,7 @@ describe('mediaLibrary', () => {
     const result = await fetchVideoAssetsWithPagination('start', 1);
     expect(result.assets).toHaveLength(1);
     expect(result.endCursor).toBe('start-end');
+    expect(result.totalCount).toBe(1);
     expect(MediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);
   });
 
@@ -201,6 +215,7 @@ describe('mediaLibrary', () => {
       MediaLibrary.MediaType.photo as any
     );
     expect(result.assets).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
     expect(MediaLibrary.getAlbumAsync).toHaveBeenCalledWith('WhatsApp Images');
   });
 

--- a/__tests__/photoAnalyzer.test.ts
+++ b/__tests__/photoAnalyzer.test.ts
@@ -7,6 +7,7 @@ import * as media from '../lib/mediaLibrary';
 
 jest.mock('../lib/mediaLibrary', () => ({
   fetchAllPhotoAssets: jest.fn(),
+  fetchPhotoAssetsWithPagination: jest.fn(),
   getAssetInfo: jest.fn(),
 }));
 
@@ -82,10 +83,19 @@ describe('photoAnalyzer', () => {
   });
 
   it('reports progress during analysis', async () => {
-    (media.fetchAllPhotoAssets as jest.Mock).mockResolvedValue([
-      { id: '1', uri: 'u1' },
-      { id: '2', uri: 'u2' },
-    ]);
+    (media.fetchPhotoAssetsWithPagination as jest.Mock)
+      .mockResolvedValueOnce({
+        assets: [{ id: '1', uri: 'u1' }],
+        hasNextPage: true,
+        endCursor: 'c1',
+        totalCount: 2,
+      })
+      .mockResolvedValueOnce({
+        assets: [{ id: '2', uri: 'u2' }],
+        hasNextPage: false,
+        endCursor: 'c2',
+        totalCount: 2,
+      });
     (media.getAssetInfo as jest.Mock).mockResolvedValue({
       id: '1',
       uri: 'u1',

--- a/app/(tabs)/months.tsx
+++ b/app/(tabs)/months.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Alert, TouchableOpacity, ScrollView } from 'react-native';
 import { Container } from '~/components/Container';
 import { Text } from '~/components/nativewindui/Text';
@@ -27,7 +27,7 @@ const generateMonths = (count: number = 12): Month[] => {
 
 export default function Months() {
   const [busy, setBusy] = useState(false);
-  const months = generateMonths(12);
+  const months = useMemo(() => generateMonths(12), []);
 
   const handleDelete = async (m: Month) => {
     Alert.alert('Delete Month', `Remove all photos from ${m.label}?`, [

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,7 +20,7 @@ import { audioService } from '~/lib/audioService';
 import { NAV_THEME } from '~/theme';
 import { RetroOverlay } from '~/components/RetroOverlay';
 if (__DEV__) {
-  require('expo-dev-client');
+  void import('expo-dev-client');
 }
 
 export function ErrorBoundary({ error }: { error: Error }) {

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -469,6 +469,17 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     ]);
   };
 
+  const currentIndexRef = React.useRef(0);
+  const photosRef = React.useRef<SwipeDeckItem[]>([]);
+
+  useEffect(() => {
+    currentIndexRef.current = currentPhotoIndex;
+  }, [currentPhotoIndex]);
+
+  useEffect(() => {
+    photosRef.current = photos;
+  }, [photos]);
+
   useEffect(() => {
     return () => {
       if (turboRef.current) {
@@ -477,30 +488,32 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     };
   }, []);
 
-  const startTurbo = () => {
-    if (turboRef.current) return;
-    setTurbo(true);
-    turboRef.current = setInterval(() => {
-      if (!deckRef.current) return;
-      deckRef.current.swipeLeft();
-      if (currentPhotoIndex >= photos.length - 1) {
-        stopTurbo();
-      }
-    }, 120);
-  };
-
-  const stopTurbo = () => {
+  const stopTurbo = React.useCallback(() => {
     if (turboRef.current) {
       clearInterval(turboRef.current);
       turboRef.current = null;
     }
     setTurbo(false);
-  };
+  }, []);
 
-  useShake(() => {
+  const startTurbo = React.useCallback(() => {
+    if (turboRef.current) return;
+    setTurbo(true);
+    turboRef.current = setInterval(() => {
+      if (!deckRef.current) return;
+      deckRef.current.swipeLeft();
+      if (currentIndexRef.current >= photosRef.current.length - 1) {
+        stopTurbo();
+      }
+    }, 120);
+  }, [stopTurbo]);
+
+  const handleShake = React.useCallback(() => {
     startTurbo();
     setTimeout(stopTurbo, 1500);
-  });
+  }, [startTurbo, stopTurbo]);
+
+  useShake(handleShake);
 
   if (loading) {
     return (

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,6 +6,7 @@ if (typeof global !== 'undefined') {
 
 // Silence Alert dialogs in tests
 try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { Alert } = require('react-native');
   if (Alert && Alert.alert) {
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- track latest gallery state with refs for turbo mode
- memoize shake handler so the accelerometer listener isn't recreated
- fix formatting in TODO list
- cache month list in Months screen
- dynamically load dev client
- silence Alert requires in tests
- expose totalCount in pagination helpers
- stream photo analysis page by page and report progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68764d7665d8832b871d1dfbe3b2b54a