### PR TITLE
Fix Jest setup lint rule and add TODOs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,8 @@
   - Change default swipe actions to navigation.
   - Optionally move the image strip to the bottom.
   - ~~Button to open the current photo in the system gallery.~~ Added open button in `PhotoGallery`.
-  - ~~Add video review support.~~ Videos tab uses `PhotoGallery` with `mediaType="video"`.
+- ~~Add video review support.~~ Videos tab uses `PhotoGallery` with `mediaType="video"`.
+- [ ] Investigate occasional failures opening assets via `Linking.openURL`
 
 ## Long Term
 - ~~Mark images as favourites or move/copy them to another album.~~ Done: photos can now be moved to any album via the new folder button.
@@ -20,3 +21,4 @@
 - [ ] Optimize memory usage when analyzing large photo libraries
 - [ ] Update Jest configuration to remove `ts-jest` deprecation warnings
 - [ ] Replace `react-test-renderer` usage in tests to avoid deprecation notices
+- [ ] Investigate using the React Native Jest preset for cleaner imports in tests

--- a/components/nativewindui/ProgressIndicator.tsx
+++ b/components/nativewindui/ProgressIndicator.tsx
@@ -77,6 +77,6 @@ function defaultGetValueLabel(value: number, max: number) {
   return `${Math.round((value / max) * 100)}%`;
 }
 
-function isValidValueNumber(value: any, max: number): value is number {
-  return typeof value === 'number' && !isNaN(value) && value <= max && value >= 0;
+function isValidValueNumber(value: unknown, max: number): value is number {
+  return typeof value === 'number' && !Number.isNaN(value) && value <= max && value >= 0;
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,7 +6,7 @@ if (typeof global !== 'undefined') {
 
 // Silence Alert dialogs in tests
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Alert } = require('react-native');
   if (Alert && Alert.alert) {
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});

--- a/lib/mediaLibrary.ts
+++ b/lib/mediaLibrary.ts
@@ -363,6 +363,7 @@ export async function openPhotoAsset(assetId: string): Promise<boolean> {
       return false;
     }
 
+    // TODO: Investigate intermittent failures when opening assets via Linking.openURL
     const { Linking } = await import('react-native');
     await Linking.openURL(info.uri);
     return true;

--- a/store/store.ts
+++ b/store/store.ts
@@ -278,9 +278,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
   purgeExpiredPhotos: async () => {
     const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
     const now = Date.now();
-    const expired = get().deletedPhotos.filter(
-      (p) => now - new Date(p.deletedAt).getTime() > THIRTY_DAYS_MS
-    );
+    const expired = get().deletedPhotos.filter((p) => now - p.deletedAt.getTime() > THIRTY_DAYS_MS);
 
     if (expired.length === 0) {
       return;
@@ -295,7 +293,7 @@ export const useRecycleBinStore = create<RecycleBinState>((set, get) => ({
     }
 
     const updated = get().deletedPhotos.filter(
-      (p) => now - new Date(p.deletedAt).getTime() <= THIRTY_DAYS_MS
+      (p) => now - p.deletedAt.getTime() <= THIRTY_DAYS_MS
     );
     set({ deletedPhotos: updated });
     await get().saveDeletedPhotos(updated);


### PR DESCRIPTION
## Summary
- adjust require rule suppression in Jest setup
- tighten type check in progress indicator
- note intermittent Linking.openURL failures
- suggest using the React Native Jest preset

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876a22040ec832b8e2536f022cfda77