### PR TITLE
Add AAB to APK guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ docs/
 ├── onboarding.md  # onboarding flow
 ├── ci.md          # CI setup
 ├── android.md     # emulator troubleshooting
+├── aab.md         # convert bundles to APKs
 ├── video.md       # handling video assets
 ├── gameplay.md    # swipe mechanics and feedback
 ├── architecture.md # module overview

--- a/docs/aab.md
+++ b/docs/aab.md
@@ -1,0 +1,10 @@
+# AAB to APK
+
+Builds from EAS or `npx expo run:android` produce `.aab` bundles. To sideload an APK, download Google's [bundletool](https://developer.android.com/studio/command-line/bundletool) and run:
+
+```bash
+java -jar bundletool.jar build-apks --bundle my-release.aab \
+  --output output.apks --mode universal
+```
+
+Unzip `output.apks` and install `universal.apk` with `adb install universal.apk`. Use `--ks` and `--ks-key-alias` to sign with your keystore if needed.


### PR DESCRIPTION
## Summary
- document how to convert an Android App Bundle to an APK
- list the new doc in the documentation index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877a0d8d4bc832b8eb94be12023655e