### PR TITLE
Document MainActivity splash fix

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -3,3 +3,18 @@
 Use `npx expo run:android` to build and launch the development client. The old global `expo` package fails on Node 17+.
 
 If you see `spawn emulator ENOENT`, install Android Studio and create a virtual device. Ensure the `emulator` command is in your `PATH` or set `ANDROID_HOME` to the SDK location.
+
+## Gray screen after launch
+
+If the game remains on a gray background after the splash screen,
+check `android/app/src/main/java/com/jaiswarup/decluttr/MainActivity.kt`.
+The `onCreate` method must pass along the incoming `savedInstanceState` bundle:
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+  setTheme(R.style.AppTheme)
+  super.onCreate(savedInstanceState)
+}
+```
+
+Passing `null` breaks `expo-splash-screen`, revealing a blank window before the React UI renders.


### PR DESCRIPTION
## Summary
- revert fallback font timeout
- document Android fix for gray screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ff1b50380832ba08014f0a1515fca