### PR TITLE
Improve memory and audio performance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 - Share images without captions or as documents.
 - Compress or resize photos and offer basic editing tools.
 - AI-based sorting into categories like selfies or pets.
-- [ ] Optimize memory usage when analyzing large photo libraries
+- ~~Optimize memory usage when analyzing large photo libraries~~ Implemented batched scanning
 - [ ] Update Jest configuration to remove `ts-jest` deprecation warnings
 - [ ] Replace `react-test-renderer` usage in tests to avoid deprecation notices
 - [ ] Investigate using the React Native Jest preset for cleaner imports in tests

--- a/__tests__/photoAnalyzer.test.ts
+++ b/__tests__/photoAnalyzer.test.ts
@@ -6,7 +6,6 @@ import {
 import * as media from '../lib/mediaLibrary';
 
 jest.mock('../lib/mediaLibrary', () => ({
-  fetchAllPhotoAssets: jest.fn(),
   fetchPhotoAssetsWithPagination: jest.fn(),
   getAssetInfo: jest.fn(),
 }));
@@ -17,12 +16,17 @@ describe('photoAnalyzer', () => {
   });
 
   it('categorizes orientation and finds duplicates', async () => {
-    (media.fetchAllPhotoAssets as jest.Mock).mockResolvedValue([
-      { id: '1', uri: 'u1' },
-      { id: '2', uri: 'u2' },
-      { id: '3', uri: 'u3' },
-      { id: '4', uri: 'u4' },
-    ]);
+    (media.fetchPhotoAssetsWithPagination as jest.Mock).mockResolvedValueOnce({
+      assets: [
+        { id: '1', uri: 'u1' },
+        { id: '2', uri: 'u2' },
+        { id: '3', uri: 'u3' },
+        { id: '4', uri: 'u4' },
+      ],
+      hasNextPage: false,
+      endCursor: undefined,
+      totalCount: 4,
+    });
     (media.getAssetInfo as jest.Mock).mockImplementation((id: string) => {
       switch (id) {
         case '1':
@@ -116,11 +120,16 @@ describe('photoAnalyzer', () => {
   });
 
   it('suggests deletion candidates', async () => {
-    (media.fetchAllPhotoAssets as jest.Mock).mockResolvedValue([
-      { id: '1', uri: 'u1' },
-      { id: '2', uri: 'u2' },
-      { id: '3', uri: 'u3' },
-    ]);
+    (media.fetchPhotoAssetsWithPagination as jest.Mock).mockResolvedValueOnce({
+      assets: [
+        { id: '1', uri: 'u1' },
+        { id: '2', uri: 'u2' },
+        { id: '3', uri: 'u3' },
+      ],
+      hasNextPage: false,
+      endCursor: undefined,
+      totalCount: 3,
+    });
 
     (media.getAssetInfo as jest.Mock).mockImplementation((id: string) => {
       switch (id) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,6 +11,8 @@ import { ErrorFallback } from '~/components/ErrorFallback';
 import { StatusBar } from 'expo-status-bar';
 
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { AppState } from 'react-native';
+import { resetMediaLibraryPermissionCache } from '~/lib/mediaLibrary';
 
 import { useColorScheme, useInitialAndroidBarSync } from '~/lib/useColorScheme';
 import { useRecycleBinStore } from '~/store/store';
@@ -80,6 +82,15 @@ export default function RootLayout() {
   //     audioService.cleanup().catch(() => {});
   //   };
   // }, [fontsLoaded]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        resetMediaLibraryPermissionCache();
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   if (!fontsLoaded) {
     return null;

--- a/lib/photoAnalyzer.ts
+++ b/lib/photoAnalyzer.ts
@@ -1,9 +1,4 @@
-import {
-  fetchAllPhotoAssets,
-  fetchPhotoAssetsWithPagination,
-  getAssetInfo,
-  PhotoAsset,
-} from './mediaLibrary';
+import { fetchPhotoAssetsWithPagination, getAssetInfo, PhotoAsset } from './mediaLibrary';
 
 export type Orientation = 'portrait' | 'landscape' | 'square';
 
@@ -20,68 +15,8 @@ export interface PhotoAnalysisResult {
  * Analyze all photos on the device to categorize by orientation and find duplicate images.
  * Duplicate detection is based on filename, dimensions and file size.
  */
-export async function analyzePhotos(): Promise<PhotoAnalysisResult> {
-  const assets = await fetchAllPhotoAssets(100);
-  const byOrientation: Record<Orientation, PhotoAsset[]> = {
-    portrait: [],
-    landscape: [],
-    square: [],
-  };
-  const dupMap: Record<string, PhotoAsset[]> = {};
-  const screenshots: PhotoAsset[] = [];
-  const selfies: PhotoAsset[] = [];
-  const oldPhotos: PhotoAsset[] = [];
-  const lowRes: PhotoAsset[] = [];
-
-  const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
-  const now = Date.now();
-
-  // Fetch detailed info for all assets concurrently for faster scanning
-  const infos = await Promise.all(assets.map((asset) => getAssetInfo(asset.id)));
-
-  infos.forEach((info, idx) => {
-    if (!info) return;
-    const asset = assets[idx];
-    const orientation: Orientation =
-      info.width > info.height ? 'landscape' : info.width < info.height ? 'portrait' : 'square';
-    byOrientation[orientation].push(asset);
-
-    if (info.width < 800 || info.height < 800) {
-      lowRes.push(asset);
-    }
-    if (info.creationTime && now - info.creationTime > ONE_YEAR_MS) {
-      oldPhotos.push(asset);
-    }
-
-    if (info.mediaSubtypes?.includes('screenshot') || /screenshot/i.test(info.filename)) {
-      screenshots.push(asset);
-    } else if (/img_|pxl_|selfie/i.test(info.filename) && orientation === 'portrait') {
-      selfies.push(asset);
-    }
-
-    const fileSize = (info as any).size ?? 0;
-    const key = `${info.width}x${info.height}_${fileSize}`;
-    if (!dupMap[key]) {
-      dupMap[key] = [];
-    }
-    dupMap[key].push(asset);
-  });
-
-  const duplicates: PhotoAsset[][] = [];
-  Object.values(dupMap).forEach((group) => {
-    if (group.length > 1) {
-      duplicates.push(group);
-    }
-  });
-
-  return {
-    byOrientation,
-    duplicates,
-    screenshots,
-    selfies,
-    oldPhotos,
-    lowRes,
-  };
+export async function analyzePhotos(batchSize: number = 20): Promise<PhotoAnalysisResult> {
+  return analyzePhotosWithProgress(undefined, batchSize);
 }
 
 /**


### PR DESCRIPTION
## Summary
- batch analyzePhotos by delegating to analyzePhotosWithProgress
- cache audio settings in AudioService
- throttle turbo mode with requestAnimationFrame
- reset media permission cache when app becomes active
- update tests and TODO list

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68801d18f900832ba6583fa9ab376b2a