### PR TITLE
Fix React and RN versions

### DIFF
--- a/codex-enhance.patch
+++ b/codex-enhance.patch
@@ -807,8 +807,8 @@ index 69da8861328e1fe9f2b2168b98ef0eddb88d4c64..6e327c28bdaa40f1480bc632f1892418
          "expo-system-ui": "~5.0.6",
          "firebase": "^10.5.2",
          "nativewind": "latest",
-         "react": "19.0.0",
-         "react-native": "0.79.2",
+          "react": "18.2.0",
+          "react-native": "0.76.0",
          "react-native-gesture-handler": "~2.24.0",
          "react-native-onboarding-swiper": "^1.3.0",
          "react-native-pager-view": "6.7.1",
@@ -821,7 +821,7 @@ index 69da8861328e1fe9f2b2168b98ef0eddb88d4c64..6e327c28bdaa40f1480bc632f1892418
        },
        "devDependencies": {
          "@babel/core": "^7.20.0",
-         "@types/react": "~19.0.10",
+        "@types/react": "~18.3.0",
          "@types/react-native": "^0.73.0",
 @@ -1759,50 +1761,56 @@
      },
@@ -878,7 +878,7 @@ index 69da8861328e1fe9f2b2168b98ef0eddb88d4c64..6e327c28bdaa40f1480bc632f1892418
          "@expo/spawn-async": "^1.7.2",
          "@expo/ws-tunnel": "^1.0.1",
          "@expo/xcpretty": "^4.3.0",
-         "@react-native/dev-middleware": "0.79.2",
+        "@react-native/dev-middleware": "0.76.0",
          "@urql/core": "^5.0.6",
 @@ -7464,60 +7472,59 @@
        },
@@ -948,7 +948,7 @@ index 69da8861328e1fe9f2b2168b98ef0eddb88d4c64..6e327c28bdaa40f1480bc632f1892418
 @@ -7680,50 +7687,63 @@
        "license": "MIT",
        "dependencies": {
-         "@react-native/normalize-colors": "0.79.2",
+        "@react-native/normalize-colors": "0.76.0",
          "debug": "^4.3.2"
        },
        "peerDependencies": {
@@ -1043,8 +1043,8 @@ index 4dccda5f51778e7defcc1b276cc10813ea0740dc..bd278b75fbc9fd4b20575a27db1f9b65
 +    "@expo-google-fonts/quicksand": "^0.2.2",
      "firebase": "^10.5.2",
      "nativewind": "latest",
-     "react": "19.0.0",
-     "react-native": "0.79.2",
+    "react": "18.2.0",
+    "react-native": "0.76.0",
      "react-native-gesture-handler": "~2.24.0",
      "react-native-onboarding-swiper": "^1.3.0",
      "react-native-pager-view": "6.7.1",
@@ -1057,7 +1057,7 @@ index 4dccda5f51778e7defcc1b276cc10813ea0740dc..bd278b75fbc9fd4b20575a27db1f9b65
    },
    "devDependencies": {
      "@babel/core": "^7.20.0",
-     "@types/react": "~19.0.10",
+    "@types/react": "~18.3.0",
      "@types/react-native": "^0.73.0",
      "@types/react-native-onboarding-swiper": "^1.1.9",
      "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/jest": "^29.5.3",
-    "@types/react": "~19.0.10",
+    "@types/react": "~18.3.0",
     "@types/react-native-onboarding-swiper": "^1.1.9",
     "ajv": "^8.12.0",
     "eslint": "^9.25.1",
@@ -83,7 +83,7 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
-    "react-test-renderer": "19.0.0",
+    "react-test-renderer": "18.2.0",
     "tailwindcss": "^3.4.0",
     "ts-jest": "^29.1.1",
     "typescript": "~5.8.3"


### PR DESCRIPTION
## Summary
- use React 18.2 with React Native 0.76.0 in package.json
- adjust codex-enhance patch to match React 18.2 and RN 0.76
- update type definitions to React 18

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688491f3efb0832b8af4fd579d40deca